### PR TITLE
TNM-3919 deserialize missing fields of JSON type array to Nil

### DIFF
--- a/ocpi-endpoints-cpo-locations/src/test/scala/com/thenewmotion/ocpi/locations/CpoLocationsRouteSpec.scala
+++ b/ocpi-endpoints-cpo-locations/src/test/scala/com/thenewmotion/ocpi/locations/CpoLocationsRouteSpec.scala
@@ -137,16 +137,12 @@ class CpoLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
          |        "last_updated": "2016-12-31T23:59:59Z",
          |        "evse_id": "ICEEVE000123_1",
          |        "status": "AVAILABLE",
-         |        "status_schedule": [],
          |        "capabilities": [
          |            "RESERVABLE"
          |        ],
          |        "connectors": [$evse1conn1String, $evse1conn2String],
          |        "physical_reference": "1",
-         |        "floor_level": "-1",
-         |        "directions": [],
-         |        "parking_restrictions": [],
-         |        "images": []
+         |        "floor_level": "-1"
          |
          | }
        """.stripMargin
@@ -158,7 +154,6 @@ class CpoLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
          |        "last_updated": "2016-12-31T23:59:59Z",
          |        "evse_id": "ICEEVE000123_2",
          |        "status": "RESERVED",
-         |        "status_schedule": [],
          |        "capabilities": [
          |            "RESERVABLE"
          |        ],
@@ -174,10 +169,7 @@ class CpoLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
          |            "tariff_id": "12"
          |        }],
          |        "physical_reference": "2",
-         |        "floor_level": "-2",
-         |        "directions": [],
-         |        "parking_restrictions": [],
-         |        "images": []
+         |        "floor_level": "-2"
          | }
        """.stripMargin
 
@@ -195,11 +187,7 @@ class CpoLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
                        |        "latitude": "52.364115",
                        |        "longitude": "4.891733"
                        |    },
-                       |    "related_locations": [],
                        |    "evses": [$evse1String, $evse2String],
-                       |    "directions": [],
-                       |    "images": [],
-                       |    "facilities": [],
                        |    "operator": {
                        |        "name": "The New Motion"
                        |    }

--- a/ocpi-endpoints-msp-locations/src/test/scala/com/thenewmotion/ocpi/locations/MspLocationsRouteSpec.scala
+++ b/ocpi-endpoints-msp-locations/src/test/scala/com/thenewmotion/ocpi/locations/MspLocationsRouteSpec.scala
@@ -156,13 +156,11 @@ class MspLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
                        |        "latitude": "52.364115",
                        |        "longitude": "4.891733"
                        |    },
-                       |    "related_locations": [],
                        |    "evses": [{
                        |        "uid": "3256",
                        |        "last_updated": "2014-06-25T00:00:00+02:00",
                        |        "id": "ICEEVE000123_1",
                        |        "status": "AVAILABLE",
-                       |        "status_schedule": [],
                        |        "capabilities": [
                        |            "RESERVABLE"
                        |        ],
@@ -188,16 +186,12 @@ class MspLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
                        |            "tariff_id": "11"
                        |        }],
                        |        "physical_reference": "1",
-                       |        "floor_level": "-1",
-                       |        "directions": [],
-                       |        "parking_restrictions": [],
-                       |        "images": []
+                       |        "floor_level": "-1"
                        |    }, {
                        |        "uid": "3257",
                        |        "last_updated": "2014-06-25T00:00:00+02:00",
                        |        "id": "ICEEVE000123_2",
                        |        "status": "RESERVED",
-                       |        "status_schedule": [],
                        |        "capabilities": [
                        |            "RESERVABLE"
                        |        ],
@@ -213,14 +207,8 @@ class MspLocationsRouteSpec extends Specification with Specs2RouteTest with Mock
                        |            "tariff_id": "12"
                        |        }],
                        |        "physical_reference": "2",
-                       |        "floor_level": "-2",
-                       |        "directions": [],
-                       |        "parking_restrictions": [],
-                       |        "images": []
+                       |        "floor_level": "-2"
                        |    }],
-                       |    "directions": [],
-                       |    "images": [],
-                       |    "facilities":[],
                        |    "operator": {
                        |        "name": "The New Motion"
                        |    }

--- a/ocpi-msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
+++ b/ocpi-msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
@@ -8,11 +8,49 @@ import com.thenewmotion.ocpi.msgs.v2_1.Tokens._
 import com.thenewmotion.ocpi.msgs.v2_1.Versions._
 import com.github.nscala_time.time.Imports._
 import org.joda.time.format.ISODateTimeFormat
-import spray.json._
+import spray.json.{DefaultJsonProtocol, _}
+
+
 
 trait OcpiJsonProtocol extends DefaultJsonProtocol {
 
   import reflect._
+
+
+  override protected def fromField[T](value: JsValue, fieldName: String)
+    (implicit reader: JsonReader[T]) = {
+
+    val MissingMemberMsg = "Object is missing required member '"
+    def decode(x: JsObject) =
+      try reader.read(x.fields(fieldName))
+      catch {
+        case e: NoSuchElementException =>
+          deserializationError(MissingMemberMsg + fieldName + "'", e, fieldName :: Nil)
+        case DeserializationException(msg, cause, fieldNames) =>
+          deserializationError(msg, cause, fieldName :: fieldNames)
+      }
+
+    value match {
+      case x: JsObject if
+      reader.isInstanceOf[OptionFormat[_]] &
+        !x.fields.contains(fieldName) =>
+        None.asInstanceOf[T]
+
+      /*
+          This case satisfies OCPI 2.1, chapter 2.5:
+
+          '*' A list of zero or more objects. If empty, it might [...] be omitted.
+      */
+      case x: JsObject => try decode(x) catch {
+        case e@DeserializationException(msg, _, _) if msg.startsWith(MissingMemberMsg) =>
+          try decode(JsObject(x.fields + (fieldName -> JsArray.empty))) catch {
+            case _: DeserializationException => throw e
+          }
+      }
+
+      case _ => deserializationError("Object expected in field '" + fieldName + "'", fieldNames = fieldName :: Nil)
+    }
+  }
 
   private val PASS1 = """([A-Z]+)([A-Z][a-z])""".r
   private val PASS2 = """([a-z\d])([A-Z])""".r

--- a/ocpi-msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
+++ b/ocpi-msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
@@ -13,6 +13,18 @@ class CommonTypesSpecs extends SpecificationWithJUnit {
 
   import OcpiJsonProtocol._
 
+  "OcpiJsonProtocol" should {
+    "deserialize missing fields of JSON type array to empty lists" in new TestScope {
+
+      case class ListContainer(stringfield: String, listfield: List[String])
+      val json = """ { "stringfield": "abc"  } """.stripMargin.parseJson
+
+      implicit val listContainerFormat = jsonFormat2(ListContainer)
+
+      json.convertTo[ListContainer].listfield mustEqual Nil
+    }
+  }
+
   "DateTimeJsonFormat" should {
     val obj = new DateTime(2014, 1, 28, 17, 30, 0, UTC).withZone(DateTimeZone.getDefault)
     val str = "2014-01-28T17:30:00Z"


### PR DESCRIPTION
2nd try, this time with a workaround: if at first you can't succeed, try try again. (try deserializing with the fieldname you're looking for set to an empty array)