### PR TITLE
Use params instead of token when matching GenericHttpCredentails

### DIFF
--- a/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
+++ b/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
@@ -1,22 +1,24 @@
 package com.thenewmotion.ocpi.common
 
-import akka.http.scaladsl.model.headers.{GenericHttpCredentials, HttpChallenge, HttpCredentials}
+import akka.http.scaladsl.model.headers.GenericHttpCredentials
+import akka.http.scaladsl.model.headers.HttpChallenge
+import akka.http.scaladsl.model.headers.HttpCredentials
 import akka.http.scaladsl.server.directives.SecurityDirectives.AuthenticationResult
 import com.thenewmotion.ocpi.ApiUser
 
 import scala.concurrent.Future
 
 class TokenAuthenticator(
-  apiUser: String => Option[ApiUser]
+  toApiUser: String => Option[ApiUser]
 ) extends (Option[HttpCredentials] ⇒ Future[AuthenticationResult[ApiUser]]) {
   override def apply(credentials: Option[HttpCredentials]): Future[AuthenticationResult[ApiUser]] = {
     import scala.concurrent.ExecutionContext.Implicits.global
     Future(
       credentials
         .flatMap {
-          case GenericHttpCredentials("Token", token, _) => Some(token)
+          case GenericHttpCredentials("Token", _, params) => params.headOption.map(_._2)
           case _ => None
-        } flatMap apiUser match {
+        } flatMap toApiUser match {
         case Some(x) => Right(x)
         case None => Left(HttpChallenge(scheme = "Token", realm = "ocpi"))
       }

--- a/ocpi-endpoints-toplevel/src/test/scala/com/thenewmotion/ocpi/TopLevelRouteSpec.scala
+++ b/ocpi-endpoints-toplevel/src/test/scala/com/thenewmotion/ocpi/TopLevelRouteSpec.scala
@@ -97,9 +97,9 @@ class TopLevelRouteSpec extends Specification with Specs2RouteTest with Mockito{
   }
 
   trait TopLevelScope extends Scope with JsonApi {
-    val validToken = Authorization(GenericHttpCredentials("Token", "12345"))
+    val validToken = Authorization(GenericHttpCredentials("Token", Map("" -> "12345")))
     val invalidHeaderName = RawHeader("Auth", "Token 12345")
-    val invalidToken = Authorization(GenericHttpCredentials("Token", "letmein"))
+    val invalidToken = Authorization(GenericHttpCredentials("Token", Map("" -> "letmein")))
 
     val ourCredentialsRoute = (version: VersionNumber, apiUser: ApiUser) => complete((StatusCodes.OK, s"credentials: $version"))
     val ourLocationsRoute = (version: VersionNumber, apiUser: ApiUser) => complete((StatusCodes.OK, s"locations: $version"))


### PR DESCRIPTION
GenericHttpCredentials token value is never set when making a real client call.
We should use params instead. The client can then specify:
Authorization: Token 12345 where 12345 is a parameter.