### PR TITLE
Use Akka Streams for paginated data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ val specs2 = {
 }
 
 val akkaHttpTestKit = Seq(akkaModule("http-testkit") % "test")
+val akkaStreamTestKit = Seq(akkaModule("stream-testkit") % "test")
 
 val jsonLenses = Seq("net.virtual-void" %% "json-lenses" %  "0.6.2")
 
@@ -69,7 +70,7 @@ val `ocpi-endpoints-common` = project
   .settings(
     commonSettings,
     description := "OCPI endpoints common",
-    libraryDependencies := logging ++ akka ++ scalaz ++ specs2 ++ akkaHttpTestKit
+    libraryDependencies := logging ++ akka ++ scalaz ++ specs2 ++ akkaHttpTestKit ++ akkaStreamTestKit
   )
 
 val `ocpi-endpoints-msp-locations` = project

--- a/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/AuthorizedRequests.scala
+++ b/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/AuthorizedRequests.scala
@@ -1,0 +1,25 @@
+package com.thenewmotion.ocpi.common
+
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.model.headers.GenericHttpCredentials
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import com.thenewmotion.ocpi.Logger
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AuthorizedRequests {
+
+  protected val logger = Logger(getClass)
+
+  // setup request/response logging
+  private val logRequest: HttpRequest => HttpRequest = { r => logger.debug(r.toString); r }
+  private val logResponse: HttpResponse => HttpResponse = { r => logger.debug(r.toString); r }
+
+  protected def requestWithAuth(http: HttpExt, req: HttpRequest, auth: String)
+    (implicit ec: ExecutionContext, mat: ActorMaterializer): Future[HttpResponse] = {
+    http.singleRequest(logRequest(req.addCredentials(GenericHttpCredentials("Token", auth, Map())))).map { response =>
+      logResponse(response)
+      response
+    }
+  }
+}

--- a/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiClient.scala
+++ b/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiClient.scala
@@ -2,18 +2,15 @@ package com.thenewmotion.ocpi.common
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.GenericHttpCredentials
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.{DateTime => _, _}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
 import akka.stream.ActorMaterializer
-import akka.http.scaladsl.client.RequestBuilding._
-import com.thenewmotion.ocpi._
 import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.{ErrorResp, _}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
-import scalaz.{EitherT, \/, \/-}
-import scalaz.std.scalaFuture._
+import scalaz.{-\/, \/, \/-}
+import akka.stream.scaladsl.Sink
+import com.github.nscala_time.time.Imports._
 
 //cf. chapter 3.1.3 from the OCPI 2.1 spec
 class ClientObjectUri (val value: Uri) extends AnyVal
@@ -25,75 +22,28 @@ object ClientObjectUri {
     uid: String) = new ClientObjectUri(endpointUri.withPath(endpointUri.path / ourCountryCode / ourPartyId / uid))
 }
 
-abstract class OcpiClient(MaxNumItems: Int = 100)(implicit actorSystem: ActorSystem, materializer: ActorMaterializer)
-  extends DisjunctionMarshalling with OcpiResponseUnmarshalling {
+case class OcpiClientException(errorResp: ErrorResp) extends Throwable
 
-  private val http = Http()
+abstract class OcpiClient(MaxNumItems: Int = 100)(implicit system: ActorSystem)
+  extends AuthorizedRequests with DisjunctionMarshalling with OcpiResponseUnmarshalling {
 
-  protected val logger = Logger(getClass)
+  protected lazy val http = Http()
 
-  // setup request/response logging
-  private val logRequest: HttpRequest => HttpRequest = { r => logger.debug(r.toString); r }
-  private val logResponse: HttpResponse => HttpResponse = { r => logger.debug(r.toString); r }
-
-  protected[ocpi] def setPageLimit(linkUri: Uri) = {
-    val newLimit = linkUri.query().get("limit").map(_.toInt min MaxNumItems) getOrElse MaxNumItems
-    val newQuery = Query(linkUri.query().toMap + ("limit" -> newLimit.toString))
-    linkUri withQuery newQuery
-  }
-
-  protected def requestWithAuth(req: HttpRequest, auth: String)(implicit ec: ExecutionContext): Future[HttpResponse] = {
-    http.singleRequest(logRequest(req.addCredentials(GenericHttpCredentials("Token", auth, Map())))).map { response =>
-      logResponse(response)
-      response
-    }
-  }
+  type ErrUnMar = FromEntityUnmarshaller[ErrorResp]
+  type SucUnMar[T] = FromEntityUnmarshaller[PagedResp[T]]
 
   def singleRequest[T <: SuccessResponse : FromEntityUnmarshaller : ClassTag](req: HttpRequest, auth: String)
-    (implicit ec: ExecutionContext, eumErr: FromEntityUnmarshaller[ErrorResp]): Future[ErrorResp \/ T] =
-    requestWithAuth(req, auth).flatMap { response =>
+    (implicit ec: ExecutionContext, mat: ActorMaterializer, errorU: ErrUnMar): Future[ErrorResp \/ T] =
+    requestWithAuth(http, req, auth).flatMap { response =>
       Unmarshal(response).to[ErrorResp \/ T]
     }
 
-  type FTS[T] = Future[ErrorResp \/ Iterable[T]]
-
   def traversePaginatedResource[T]
-    (uri: Uri, auth: String, queryParams: Map[String, String] = Map.empty, limit: Int = MaxNumItems)
-    (implicit ec: ExecutionContext,
-     successUnmarshaller: FromEntityUnmarshaller[SuccessWithDataResp[Iterable[T]]],
-     errorUnmarshaller: FromEntityUnmarshaller[ErrorResp]): FTS[T] = {
-      val fullParams = Query(Map(
-          "offset" -> "0",
-          "limit" -> limit.toString) ++ queryParams)
-      _traversePaginatedResource(uri withQuery fullParams, auth)
+    (uri: Uri, auth: String, dateFrom: Option[DateTime] = None, dateTo: Option[DateTime] = None, limit: Int = MaxNumItems)
+    (implicit ec: ExecutionContext, mat: ActorMaterializer, successU: SucUnMar[T], errorU: ErrUnMar): Future[ErrorResp \/ Iterable[T]] =
+    PaginatedSource[T](http, uri, auth, dateFrom, dateTo, limit).runWith(Sink.seq[T]).map {
+      \/-(_)
+    }.recover {
+      case OcpiClientException(errorResp) => -\/(errorResp)
     }
-
-  type Result[E, T] = EitherT[Future, E, T]
-
-  def result[L, T](future: Future[L \/ T]): Result[L, T] = EitherT(future)
-
-  private def _traversePaginatedResource[T](uri: Uri, auth: String)
-    (implicit ec: ExecutionContext,
-     successUnmarshaller: FromEntityUnmarshaller[SuccessWithDataResp[Iterable[T]]],
-     errorUnmarshaller: FromEntityUnmarshaller[ErrorResp]): FTS[T] = {
-
-    def withNextPage(data: Iterable[T], nextUriOpt: Option[Uri]): Future[\/[ErrorResp, Iterable[T]]] =
-      nextUriOpt.map { nextUri =>
-        logger.debug(s"following Link: $nextUri")
-        _traversePaginatedResource(setPageLimit(nextUri), auth)
-      }.fold(Future.successful(\/-(data): ErrorResp \/ Iterable[T])) { n =>
-        (for {
-          next <- result(n)
-        } yield {
-          data ++ next
-        }).run
-      }
-
-    (for {
-      response <- result(requestWithAuth(Get(uri), auth).map(\/-(_)))
-      success <- result(Unmarshal(response).to[ErrorResp \/ (PagedResp[T], Option[Uri])])
-      (entity, nextUriOpt) = success
-      x <- result(withNextPage(entity.data, nextUriOpt))
-    } yield x).run
-  }
 }

--- a/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
+++ b/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
@@ -1,0 +1,45 @@
+package com.thenewmotion.ocpi.common
+
+import akka.NotUsed
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.{HttpRequest, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import com.github.nscala_time.time.Imports.DateTime
+import com.thenewmotion.ocpi.formatterNoMillis
+import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.ErrorResp
+import scala.concurrent.{ExecutionContext, Future}
+import scalaz._, Scalaz._
+
+object PaginatedSource extends AuthorizedRequests with DisjunctionMarshalling with OcpiResponseUnmarshalling {
+  private def singleRequestWithNextLink[T](http: HttpExt, req: HttpRequest, auth: String)
+    (implicit ec: ExecutionContext, mat: ActorMaterializer, successU: SucUnMar[T],
+     errorU: ErrUnMar): Future[\/[ErrorResp, (PagedResp[T], Option[Uri])]] =
+    (for {
+      response <- result(requestWithAuth(http, req, auth).map(\/-(_)))
+      success <- result(Unmarshal(response).to[ErrorResp \/ (PagedResp[T], Option[Uri])])
+    } yield success).run
+
+  def apply[T](http: HttpExt, uri: Uri, auth: String, dateFrom: Option[DateTime] = None,
+    dateTo: Option[DateTime] = None, limit: Int = 100)
+    (implicit ec: ExecutionContext, mat: ActorMaterializer, successU: SucUnMar[T], errorU: ErrUnMar): Source[T, NotUsed] = {
+    val query = Query(Map(
+      "offset" -> "0",
+      "limit" -> limit.toString) ++
+      dateFrom.map("date_from" -> formatterNoMillis.print(_)) ++
+      dateTo.map("date_to" -> formatterNoMillis.print(_))
+    )
+
+    Source.unfoldAsync[Option[Uri], Iterable[T]](Some(uri withQuery query)) {
+      case Some(x) =>
+        singleRequestWithNextLink[T](http, Get(x), auth).map {
+          case -\/(err) => throw OcpiClientException(err)
+          case \/-((success, u)) => Some((u, success.data))
+        }
+      case None => Future.successful(None)
+    }.mapConcat(_.toList)
+  }
+}

--- a/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/package.scala
+++ b/ocpi-endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/package.scala
@@ -1,0 +1,16 @@
+package com.thenewmotion.ocpi
+
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import com.thenewmotion.ocpi.common.PaginatedSource.PagedResp
+import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.ErrorResp
+import scala.concurrent.Future
+import scalaz.{EitherT, \/}
+
+package object common {
+  type ErrUnMar = FromEntityUnmarshaller[ErrorResp]
+  type SucUnMar[T] = FromEntityUnmarshaller[PagedResp[T]]
+
+  type Result[E, T] = EitherT[Future, E, T]
+
+  def result[L, T](future: Future[L \/ T]): Result[L, T] = EitherT(future)
+}

--- a/ocpi-endpoints-common/src/test/scala/com/thenewmotion/ocpi/PaginatedSourceSpec.scala
+++ b/ocpi-endpoints-common/src/test/scala/com/thenewmotion/ocpi/PaginatedSourceSpec.scala
@@ -1,0 +1,149 @@
+package com.thenewmotion.ocpi
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse, Uri}
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.headers.{GenericHttpCredentials, Link, LinkParams, RawHeader}
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestProbe
+import com.thenewmotion.ocpi.common.PaginatedSource
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import akka.http.scaladsl.client.RequestBuilding._
+import akka.http.scaladsl.model.Uri.Query
+import org.mockito.Matchers
+
+import scala.concurrent.Future
+
+class PaginatedSourceSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+
+  import com.thenewmotion.ocpi.msgs.v2_1.OcpiJsonProtocol._
+  import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+
+  case class TestData(id: String)
+  implicit val testDataFormat = jsonFormat1(TestData)
+
+  "PaginatedSource" should {
+    "Follow the link to the next page" in new TestScope {
+
+      implicit val ac = system
+
+      http.singleRequest(Matchers.eq(page1Req), any, any, any)(any) returns Future.successful(HttpResponse(
+        OK, entity = HttpEntity(`application/json`, s"""
+                                                       |{
+                                                       |  "status_code": 1000,
+                                                       |  "timestamp": "2010-01-01T00:00:00Z",
+                                                       |  "data": [{
+                                                       |             "id": "DATA1"
+                                                       |           },
+                                                       |           {
+                                                       |             "id": "DATA2"
+                                                       |           }]
+                                                       |}
+                                                       |""".stripMargin.getBytes),
+        headers = List(
+          Link(Uri(s"$dataUrl?offset=2&limit=2"), LinkParams.next),
+          RawHeader("X-Total-Count", "4"),
+          RawHeader("X-Limit", "2")
+        )
+      ))
+
+      http.singleRequest(Matchers.eq(page2Req), any, any, any)(any) returns Future.successful(HttpResponse(
+        OK, entity = HttpEntity(`application/json`, s"""
+                                                       |{
+                                                       |  "status_code": 1000,
+                                                       |  "timestamp": "2010-01-01T00:00:01Z",
+                                                       |  "data": [{
+                                                       |             "id": "DATA3"
+                                                       |           },
+                                                       |           {
+                                                       |             "id": "DATA4"
+                                                       |           }]
+                                                       |}
+                                                       |""".stripMargin.getBytes),
+        headers = List(
+          RawHeader("X-Total-Count", "4"),
+          RawHeader("X-Limit", "2")
+        )
+      ))
+
+      val probe = TestProbe()
+
+      PaginatedSource[TestData](http, dataUrl, "auth", limit = 2)
+        .runWith(TestSink.probe[TestData])
+        .request(5)
+        .expectNext(TestData("DATA1"), TestData("DATA2"), TestData("DATA3"), TestData("DATA4"))
+        .expectComplete()
+    }
+
+    "Handle OCPI error" in new TestScope {
+
+      implicit val ac = system
+
+      http.singleRequest(Matchers.eq(page1Req), any, any, any)(any) returns Future.successful(HttpResponse(
+        OK, entity = HttpEntity(`application/json`, s"""
+                                                       |{
+                                                       |  "status_code": 1000,
+                                                       |  "timestamp": "2010-01-01T00:00:00Z",
+                                                       |  "data": [{
+                                                       |             "id": "DATA1"
+                                                       |           },
+                                                       |           {
+                                                       |             "id": "DATA2"
+                                                       |           }]
+                                                       |}
+                                                       |""".stripMargin.getBytes),
+        headers = List(
+          Link(Uri(s"$dataUrl?offset=2&limit=2"), LinkParams.next),
+          RawHeader("X-Total-Count", "4"),
+          RawHeader("X-Limit", "2")
+        )
+      ))
+
+      http.singleRequest(Matchers.eq(page2Req), any, any, any)(any) returns Future.successful(HttpResponse(
+        OK, entity = HttpEntity(`application/json`, s"""
+                                                     |{
+                                                     |  "status_code": 2000,
+                                                     |  "status_message": "something went horribly wrong...",
+                                                     |  "timestamp": "2010-01-01T00:00:00Z"
+                                                     |}
+                                                     |""".stripMargin.getBytes)
+      ))
+
+      val probe = TestProbe()
+
+      PaginatedSource[TestData](http, dataUrl, "auth", limit = 2)
+        .runWith(TestSink.probe[TestData])
+        .request(5)
+        .expectNext(TestData("DATA1"), TestData("DATA2"))
+        .expectError()
+    }
+  }
+
+  trait TestScope extends Scope {
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    val dataUrl = "http://localhost:8095/cpo/versions/2.0/somemodule"
+
+    val http = mock[HttpExt]
+
+    val baseReq = Get(Uri(dataUrl)).addCredentials(GenericHttpCredentials("Token", "auth", Map()))
+
+    val page1Req = baseReq.withUri(baseReq.uri.withQuery(Query(Map(
+      "offset" -> "0",
+      "limit"  -> "2"
+    ))))
+
+    val page2Req = baseReq.withUri(baseReq.uri.withQuery(Query(Map(
+      "offset" -> "2",
+      "limit"  -> "2"
+    ))))
+  }
+
+}

--- a/ocpi-endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
+++ b/ocpi-endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
@@ -1,30 +1,28 @@
 package com.thenewmotion.ocpi
 package locations
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import com.thenewmotion.ocpi.common.OcpiClient
+import com.thenewmotion.ocpi.common.{OcpiClient, PaginatedSource}
 import com.thenewmotion.ocpi.msgs.v2_1.Locations.Location
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz._
 import com.github.nscala_time.time.Imports._
 import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.ErrorResp
 
-class LocationsClient(implicit actorSystem: ActorSystem, materializer: ActorMaterializer) extends OcpiClient {
+class LocationsClient(implicit actorSystem: ActorSystem) extends OcpiClient {
   import com.thenewmotion.ocpi.msgs.v2_1.OcpiJsonProtocol._
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 
-
   def getLocations(uri: Uri, auth: String, dateFrom: Option[DateTime] = None, dateTo: Option[DateTime] = None)
-    (implicit ec: ExecutionContext): Future[ErrorResp \/ Iterable[Location]] = {
+    (implicit ec: ExecutionContext, mat: ActorMaterializer): Future[ErrorResp \/ Iterable[Location]] =
+    traversePaginatedResource[Location](uri, auth, dateFrom, dateTo)
 
-    val query: Map[String, String] = Map.empty ++
-      dateFrom.map("date_from" -> formatterNoMillis.print(_)) ++
-      dateTo.map("date_to" -> formatterNoMillis.print(_))
-
-    traversePaginatedResource[Location](uri, auth, query)
-  }
+  def locationsSource(uri: Uri, auth: String, dateFrom: Option[DateTime] = None, dateTo: Option[DateTime] = None)
+                  (implicit ec: ExecutionContext, mat: ActorMaterializer): Source[Location, NotUsed] =
+    PaginatedSource[Location](http, uri, auth, dateFrom, dateTo)
 
 }
-

--- a/ocpi-endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/TokensClientSpec.scala
+++ b/ocpi-endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/TokensClientSpec.scala
@@ -2,6 +2,7 @@ package com.thenewmotion.ocpi.tokens
 
 import java.net.UnknownHostException
 import akka.actor.ActorSystem
+import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse}
 import akka.util.Timeout
 import scala.concurrent.duration.FiniteDuration
@@ -9,6 +10,7 @@ import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import akka.http.scaladsl.model.ContentTypes._
+
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz.{\/, \/-}
 import com.thenewmotion.ocpi.common.ClientObjectUri
@@ -124,7 +126,8 @@ object GenericRespTypes {
 class TestTokensClient(reqWithAuthFunc: String => Future[HttpResponse])
   (implicit actorSystem: ActorSystem, materializer: ActorMaterializer) extends TokensClient {
 
-  override def requestWithAuth(req: HttpRequest, token: String)(implicit ec: ExecutionContext): Future[HttpResponse] =
+  override def requestWithAuth(http: HttpExt, req: HttpRequest, token: String)
+    (implicit ec: ExecutionContext, mat: ActorMaterializer): Future[HttpResponse] =
     req.uri.toString match { case x => reqWithAuthFunc(x) }
 
 }


### PR DESCRIPTION
The advantages to this are simplified pagination code, and the ability for the consumer to start processing the paginated data as it arrives rather than waiting for the whole dataset