### PR TITLE
Handle missing fields of type array during deserialization

### DIFF
--- a/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
+++ b/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
@@ -89,8 +89,10 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
   implicit val environmentalImpactFormat = jsonFormat2(EnvironmentalImpact)
 
   implicit val energyMixFormat = new JsonFormat[EnergyMix] {
-    override def read(json: JsValue) = jsonFormat5(EnergyMix.deserialize).read(json)
-    override def write(obj: EnergyMix): JsValue = jsonFormat5(EnergyMix.apply).write(obj)
+    val readFormat = jsonFormat5(EnergyMix.deserialize)
+    val writeFormat = jsonFormat5(EnergyMix.apply)
+    override def read(json: JsValue) = readFormat.read(json)
+    override def write(obj: EnergyMix): JsValue = writeFormat.write(obj)
   }
   implicit val powerFormat = jsonFormat3(Power)
   implicit val displayTestFormat = jsonFormat2(DisplayText)
@@ -99,8 +101,10 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
   implicit val regularHoursFormat = jsonFormat3(RegularHours)
   implicit val exceptionalPeriodFormat = jsonFormat2(ExceptionalPeriod)
   implicit val hoursFormat = new JsonFormat[Hours] {
-    override def read(json: JsValue) = jsonFormat4(Hours.deserialize).read(json)
-    override def write(obj: Hours): JsValue = jsonFormat4(Hours.apply).write(obj)
+    val readFormat = jsonFormat4(Hours.deserialize)
+    val writeFormat = jsonFormat4(Hours.apply)
+    override def read(json: JsValue) = readFormat.read(json)
+    override def write(obj: Hours): JsValue = writeFormat.write(obj)
   }
   implicit val imageFormat = jsonFormat6(Image)
   implicit val businessDetailsFormat = jsonFormat3(BusinessDetails)
@@ -109,14 +113,18 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
   implicit val connectorPatchFormat = jsonFormat8(ConnectorPatch)
   implicit val statusScheduleFormat = jsonFormat3(StatusSchedule)
   implicit val evseFormat = new RootJsonFormat[Evse] {
-    override def read(json: JsValue) = jsonFormat13(Evse.deserialize).read(json)
-    override def write(obj: Evse): JsValue = jsonFormat13(Evse.apply).write(obj)
+    val readFormat = jsonFormat13(Evse.deserialize)
+    val writeFormat = jsonFormat13(Evse.apply)
+    override def read(json: JsValue) = readFormat.read(json)
+    override def write(obj: Evse): JsValue = writeFormat.write(obj)
   }
   implicit val evsePatchFormat = jsonFormat12(EvsePatch)
   implicit val operatorFormat = jsonFormat3(Operator)
   implicit val locationFormat = new RootJsonFormat[Location] {
-    override def read(json: JsValue) = jsonFormat21(Location.deserialize).read(json)
-    override def write(obj: Location): JsValue = jsonFormat21(Location.apply).write(obj)
+    val readFormat = jsonFormat21(Location.deserialize)
+    val writeFormat = jsonFormat21(Location.apply)
+    override def read(json: JsValue) = readFormat.read(json)
+    override def write(obj: Location): JsValue = writeFormat.write(obj)
   }
   implicit val tokensFormat = jsonFormat9(Token)
 
@@ -197,9 +205,12 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
   }
 
   implicit val locationReferencesFormat = new RootJsonFormat[LocationReferences] {
-    override def read(json: JsValue) = jsonFormat3(LocationReferences.deserialize).read(json)
-    override def write(obj: LocationReferences): JsValue = jsonFormat3(LocationReferences.apply).write(obj)
+    val readFormat = jsonFormat3(LocationReferences.deserialize)
+    val writeFormat = jsonFormat3(LocationReferences.apply)
+    override def read(json: JsValue) = readFormat.read(json)
+    override def write(obj: LocationReferences): JsValue = writeFormat.write(obj)
   }
+
   implicit val allowedFormat =
     new SimpleStringEnumSerializer[Allowed](Allowed).enumFormat
 

--- a/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
+++ b/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/OcpiJsonProtocol.scala
@@ -87,24 +87,37 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
 
   implicit val energySourceFormat = jsonFormat2(EnergySource)
   implicit val environmentalImpactFormat = jsonFormat2(EnvironmentalImpact)
-  implicit val energyMixFormat = jsonFormat5(EnergyMix)
+
+  implicit val energyMixFormat = new JsonFormat[EnergyMix] {
+    override def read(json: JsValue) = jsonFormat5(EnergyMix.deserialize).read(json)
+    override def write(obj: EnergyMix): JsValue = jsonFormat5(EnergyMix.apply).write(obj)
+  }
   implicit val powerFormat = jsonFormat3(Power)
   implicit val displayTestFormat = jsonFormat2(DisplayText)
   implicit val geoLocationFormat = jsonFormat2(GeoLocation)
   implicit val additionalGeoLocationFormat = jsonFormat3(AdditionalGeoLocation)
   implicit val regularHoursFormat = jsonFormat3(RegularHours)
   implicit val exceptionalPeriodFormat = jsonFormat2(ExceptionalPeriod)
-  implicit val hoursFormat = jsonFormat4(Hours)
+  implicit val hoursFormat = new JsonFormat[Hours] {
+    override def read(json: JsValue) = jsonFormat4(Hours.deserialize).read(json)
+    override def write(obj: Hours): JsValue = jsonFormat4(Hours.apply).write(obj)
+  }
   implicit val imageFormat = jsonFormat6(Image)
   implicit val businessDetailsFormat = jsonFormat3(BusinessDetails)
 
   implicit val connectorFormat = jsonFormat9(Connector)
   implicit val connectorPatchFormat = jsonFormat8(ConnectorPatch)
   implicit val statusScheduleFormat = jsonFormat3(StatusSchedule)
-  implicit val evseFormat = jsonFormat13(Evse)
+  implicit val evseFormat = new RootJsonFormat[Evse] {
+    override def read(json: JsValue) = jsonFormat13(Evse.deserialize).read(json)
+    override def write(obj: Evse): JsValue = jsonFormat13(Evse.apply).write(obj)
+  }
   implicit val evsePatchFormat = jsonFormat12(EvsePatch)
   implicit val operatorFormat = jsonFormat3(Operator)
-  implicit val locationFormat = jsonFormat21(Location)
+  implicit val locationFormat = new RootJsonFormat[Location] {
+    override def read(json: JsValue) = jsonFormat21(Location.deserialize).read(json)
+    override def write(obj: Location): JsValue = jsonFormat21(Location.apply).write(obj)
+  }
   implicit val tokensFormat = jsonFormat9(Token)
 
   implicit val locationPatchFormat = jsonFormat21(LocationPatch)
@@ -183,7 +196,10 @@ trait OcpiJsonProtocol extends DefaultJsonProtocol {
     }
   }
 
-  implicit val locationReferencesFormat = jsonFormat3(LocationReferences)
+  implicit val locationReferencesFormat = new RootJsonFormat[LocationReferences] {
+    override def read(json: JsValue) = jsonFormat3(LocationReferences.deserialize).read(json)
+    override def write(obj: LocationReferences): JsValue = jsonFormat3(LocationReferences.apply).write(obj)
+  }
   implicit val allowedFormat =
     new SimpleStringEnumSerializer[Allowed](Allowed).enumFormat
 

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
@@ -2,7 +2,6 @@ package com.thenewmotion.ocpi.msgs.v2_1
 
 import com.thenewmotion.ocpi.msgs.ErrorResp
 import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericClientFailure
-import com.thenewmotion.ocpi.msgs.v2_1.Locations.Hours
 import org.joda.time.DateTimeZone._
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
@@ -31,20 +30,6 @@ class CommonTypesSpecs extends SpecificationWithJUnit {
     }
     "serialize" in new TestScope {
       genericErrorResp1.toJson mustEqual genericErrorRespJson1
-    }
-  }
-
-  "Hours" should {
-    "deserialize missing fields of cardinality '*' to empty lists" in new TestScope {
-      val hours =
-        """
-          | {
-          |   "twentyfourseven": true
-          | }
-        """.stripMargin.parseJson.convertTo[Hours]
-
-      hours.exceptionalOpenings mustEqual Nil
-      hours.exceptionalClosings mustEqual Nil
     }
   }
 

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/CommonTypesSpecs.scala
@@ -2,6 +2,7 @@ package com.thenewmotion.ocpi.msgs.v2_1
 
 import com.thenewmotion.ocpi.msgs.ErrorResp
 import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericClientFailure
+import com.thenewmotion.ocpi.msgs.v2_1.Locations.Hours
 import org.joda.time.DateTimeZone._
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
@@ -29,10 +30,23 @@ class CommonTypesSpecs extends SpecificationWithJUnit {
       genericErrorRespJson1.convertTo[ErrorResp] mustEqual genericErrorResp1
     }
     "serialize" in new TestScope {
-      genericErrorResp1.toJson.toString mustEqual genericErrorRespJson1.compactPrint
+      genericErrorResp1.toJson mustEqual genericErrorRespJson1
     }
   }
 
+  "Hours" should {
+    "deserialize missing fields of cardinality '*' to empty lists" in new TestScope {
+      val hours =
+        """
+          | {
+          |   "twentyfourseven": true
+          | }
+        """.stripMargin.parseJson.convertTo[Hours]
+
+      hours.exceptionalOpenings mustEqual Nil
+      hours.exceptionalClosings mustEqual Nil
+    }
+  }
 
   private trait TestScope extends Scope {
 

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/LocationsSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/LocationsSpecs.scala
@@ -63,6 +63,18 @@ class LocationsSpecs extends SpecificationWithJUnit {
   }
 
   "EnergyMix" should {
+    "serialize/deserialize" in new Scope {
+      val emJson = """
+                 |{
+                 |      "is_green_energy": true,
+                 |      "energy_sources": [],
+                 |      "environ_impact": [],
+                 |      "supplier_name": "Greenpeace Energy eG",
+                 |      "energy_product_name": "eco-power"
+                 |}
+               """.stripMargin
+      emJson.parseJson mustEqual EnergyMix(true, Nil, Nil, Some("Greenpeace Energy eG"), Some("eco-power")).toJson
+    }
     "deserialize missing fields of cardinality '*' to empty lists" in new LocationsTestScope {
       val em = """
         |{
@@ -102,6 +114,32 @@ class LocationsSpecs extends SpecificationWithJUnit {
     }
     "extract" in {
       JsonParser("\"" + str + "\"").convertTo[PeriodType] mustEqual periodType
+    }
+  }
+
+  "Hours" should {
+    "serialize/deserialize" in new Scope {
+      val hoursJson =
+        """
+          |{
+          | "regular_hours": [],
+          | "twentyfourseven": true,
+          | "exceptional_openings": [],
+          | "exceptional_closings": []
+          |}
+        """.stripMargin.parseJson mustEqual Hours(true, Nil, Nil, Nil).toJson
+    }
+
+    "deserialize missing fields of cardinality '*' to empty lists" in new Scope {
+      val hours =
+        """
+          | {
+          |   "twentyfourseven": true
+          | }
+        """.stripMargin.parseJson.convertTo[Hours]
+
+      hours.exceptionalOpenings mustEqual Nil
+      hours.exceptionalClosings mustEqual Nil
     }
   }
 

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/LocationsSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/LocationsSpecs.scala
@@ -15,37 +15,82 @@ class LocationsSpecs extends SpecificationWithJUnit {
 
   "Evses" should {
     "deserialize" in new LocationsTestScope {
-      evseJson1.convertTo[Evse] mustEqual evse1
+      evseJson1.parseJson.convertTo[Evse] mustEqual evse1
     }
     "serialize" in new LocationsTestScope {
-      evse1.toJson.toString mustEqual evseJson1.compactPrint
+      evse1.toJson mustEqual evseJson1.parseJson
+    }
+    "deserialize missing fields of cardinality '*' to empty lists" in new LocationsTestScope {
+      val evse = evseJson1
+        .replaceAll(""""status_schedule": \[\],""", "")
+        .replaceAll(""""capabilities": \[[| \nA-Z"]+\],""", "")
+        .replaceAll(""""directions": \[\],""", "")
+        .replaceAll(""""parking_restrictions": \[\],""", "")
+        .replaceAll(""""images": \[\],""", "")
+        .parseJson.convertTo[Evse]
+
+      evse.statusSchedule mustEqual Nil
+      evse.capabilities mustEqual Nil
+      evse.directions mustEqual Nil
+      evse.parkingRestrictions mustEqual Nil
+      evse.images mustEqual Nil
     }
   }
 
    "LocationResp" should {
       "deserialize" in new LocationsTestScope {
-         locationRespJson1.convertTo[SuccessWithDataResp[List[Location]]] mustEqual locationResp1
+         locationRespJson1.parseJson.convertTo[SuccessWithDataResp[List[Location]]] mustEqual locationResp1
       }
       "serialize" in new LocationsTestScope {
-         locationResp1.toJson.toString mustEqual locationRespJson1.compactPrint
+         locationResp1.toJson mustEqual locationRespJson1.parseJson
       }
    }
 
+  "Location" should {
+    "deserialize missing fields of cardinality '*' to empty lists" in new LocationsTestScope {
+      val loc = locationJson1
+        .replaceAll(""""related_locations": \[\],""", "")
+        .replaceAll(""""directions": \[[| \na-z:{},"]+\],""", "")
+        .replaceAll(""""facilities": \[\],""", "")
+        .replaceAll(""""images": \[\],""", "")
+        .parseJson.convertTo[Location]
+
+      loc.relatedLocations mustEqual Nil
+      loc.directions mustEqual Nil
+      loc.facilities mustEqual Nil
+      loc.images mustEqual Nil
+    }
+  }
+
+  "EnergyMix" should {
+    "deserialize missing fields of cardinality '*' to empty lists" in new LocationsTestScope {
+      val em = """
+        |{
+        |      "is_green_energy": true,
+        |      "supplier_name": "Greenpeace Energy eG",
+        |      "energy_product_name": "eco-power"
+        |}
+      """.stripMargin.parseJson.convertTo[EnergyMix]
+      em.energySources mustEqual Nil
+      em.environImpact mustEqual Nil
+    }
+  }
+
   "Operator" should {
     "deserialize" in new LocationsTestScope {
-      operatorJsonWithNulls1.convertTo[Operator] mustEqual operator1
+      operatorJsonWithNulls1.parseJson.convertTo[Operator] mustEqual operator1
     }
     "serialize" in new LocationsTestScope {
-      operator1.toJson.toString mustEqual operatorJsonNoNulls1.compactPrint
+      operator1.toJson mustEqual operatorJsonNoNulls1.parseJson
     }
   }
 
   "Power" should {
     "deserialize" in new LocationsTestScope {
-      powerJson1.convertTo[Power] mustEqual power1
+      powerJson1.parseJson.convertTo[Power] mustEqual power1
     }
     "serialize" in new LocationsTestScope {
-      power1.toJson.toString mustEqual powerJson1.compactPrint
+      power1.toJson mustEqual powerJson1.parseJson
     }
   }
 
@@ -166,7 +211,14 @@ class LocationsSpecs extends SpecificationWithJUnit {
       openingTimes = Some(hours1),
       relatedLocations = List.empty,
       chargingWhenClosed = Some(true),
-      images = List.empty
+      images = List.empty,
+      energyMix = Some(EnergyMix(
+        isGreenEnergy = true,
+        energySources = Nil,
+        environImpact = Nil,
+        Some("Greenpeace Energy eG"),
+        Some("eco-power")
+      ))
     )
 
     val location2 = Location(
@@ -204,7 +256,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |  "latitude": "3.729945",
          |  "longitude": "51.047594"
          |}
-     """.stripMargin.parseJson
+     """.stripMargin
 
     val geoLocationJson2 =
       s"""
@@ -212,7 +264,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |  "latitude": "3.729955",
          |  "longitude": "51.047604"
          |}
-     """.stripMargin.parseJson
+     """.stripMargin
 
 
 
@@ -255,7 +307,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |      "physical_reference": "1",
          |      "floor_level": "-1"
          |    }
-   """.stripMargin.parseJson
+   """.stripMargin
 
 
 
@@ -289,7 +341,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |      "physical_reference": "1",
          |      "floor_level": "-1"
          |    }
-   """.stripMargin.parseJson
+   """.stripMargin
 
     val evseJson3 =
       s"""
@@ -320,7 +372,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |      "physical_reference": "2",
          |      "floor_level": "-1"
          |    }
-   """.stripMargin.parseJson
+   """.stripMargin
 
 
 
@@ -384,9 +436,16 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |		  },
          |      "facilities": [],
          |      "images":[],
-         |      "charging_when_closed": true
+         |      "charging_when_closed": true,
+         |      "energy_mix": {
+         |        "is_green_energy": true,
+         |        "energy_sources": [],
+         |        "environ_impact": [],
+         |        "supplier_name": "Greenpeace Energy eG",
+         |        "energy_product_name": "eco-power"
+         |      }
          |    }
-   """.stripMargin.parseJson
+   """.stripMargin
 
     val locationJson2 =
       s"""
@@ -407,7 +466,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |      "images":[],
          |      "charging_when_closed": true
          |    }
-   """.stripMargin.parseJson
+   """.stripMargin
 
     val locationRespJson1 =
       s"""
@@ -417,7 +476,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
          |  "timestamp": "${date1.toString(formatter)}",
          |  "data": [$locationJson1,$locationJson2]
          |}
-       """.stripMargin.parseJson
+       """.stripMargin
 
   }
 
@@ -428,14 +487,14 @@ class LocationsSpecs extends SpecificationWithJUnit {
        |  "phone": "+31253621489",
        |  "url": null
        |}
-    """.stripMargin.parseJson
+    """.stripMargin
 
   val operatorJsonNoNulls1 =
     s"""
        |{
        |  "phone": "+31253621489"
        |}
-    """.stripMargin.parseJson
+    """.stripMargin
 
   val operator1 = Operator(None, Some("+31253621489"), None)
 
@@ -446,7 +505,7 @@ class LocationsSpecs extends SpecificationWithJUnit {
        |  "amperage": 16,
        |  "voltage": 230
        |}
-     """.stripMargin.parseJson
+     """.stripMargin
 
   val power1 = Power(Some(AC3Phase), 16, 230)
 

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/TokensSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/TokensSpecs.scala
@@ -1,0 +1,27 @@
+package com.thenewmotion.ocpi.msgs.v2_1
+
+import com.thenewmotion.ocpi.msgs.v2_1.Tokens.LocationReferences
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.specification.Scope
+import spray.json._
+
+class TokensSpecs extends SpecificationWithJUnit {
+
+  import OcpiJsonProtocol._
+
+
+  "LocationReferences" should {
+    "deserialize missing fields of cardinality '*' to empty lists" in new Scope {
+      val locRefs =
+        """
+          | {
+          |   "location_id": "loc1"
+          | }
+        """.stripMargin.parseJson.convertTo[LocationReferences]
+
+      locRefs.evseUids mustEqual Nil
+      locRefs.connectorIds mustEqual Nil
+    }
+  }
+
+}

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/VersionsSpecs.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/VersionsSpecs.scala
@@ -16,7 +16,7 @@ class VersionsSpecs extends SpecificationWithJUnit {
       versionRespJson1.convertTo[SuccessWithDataResp[List[Version]]] mustEqual versionResp
     }
     "serialize" in new VersionsTestScope {
-      versionResp.toJson.toString mustEqual versionRespJson1.compactPrint
+      versionResp.toJson mustEqual versionRespJson1
     }
   }
 
@@ -26,7 +26,7 @@ class VersionsSpecs extends SpecificationWithJUnit {
       version21DetailsRespJson.convertTo[SuccessWithDataResp[VersionDetails]] mustEqual version21DetailsResp
     }
     "serialize" in new VersionsTestScope {
-      version21DetailsResp.toJson.toString mustEqual version21DetailsRespJson.compactPrint
+      version21DetailsResp.toJson mustEqual version21DetailsRespJson
     }
   }
 

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
@@ -32,6 +32,53 @@ object Locations {
     require(country.length == 3, "Location needs 3-letter, ISO 3166-1 country code!")
   }
 
+  object Location {
+    private[v2_1] def deserialize(
+      id: String,
+      lastUpdated: DateTime,
+      `type`:	LocationType,
+      name:	Option[String],
+      address: String,
+      city:	String,
+      postalCode: String,
+      country:	String,
+      coordinates:	GeoLocation,
+      relatedLocations: Option[Iterable[AdditionalGeoLocation]],
+      evses: Option[Iterable[Evse]],
+      directions:	Option[Iterable[DisplayText]],
+      operator: Option[BusinessDetails],
+      suboperator: Option[BusinessDetails],
+      owner: Option[BusinessDetails],
+      facilities: Option[Iterable[Facility]],
+      timeZone: Option[String],
+      openingTimes: Option[Hours],
+      chargingWhenClosed: Option[Boolean],
+      images: Option[Iterable[Image]],
+      energyMix: Option[EnergyMix]
+    ) = new Location(id,
+      lastUpdated,
+      `type`,
+      name,
+      address,
+      city,
+      postalCode,
+      country,
+      coordinates,
+      relatedLocations getOrElse Nil,
+      evses getOrElse Nil,
+      directions getOrElse Nil,
+      operator,
+      suboperator,
+      owner,
+      facilities getOrElse Nil,
+      timeZone,
+      openingTimes,
+      chargingWhenClosed,
+      images getOrElse Nil,
+      energyMix)
+  }
+
+
   case class LocationPatch(
     id: Option[String] = None,
     lastUpdated: Option[DateTime] = None,
@@ -129,6 +176,22 @@ object Locations {
     energyProductName: Option[String] = None
   )
 
+  object EnergyMix {
+    private[v2_1] def deserialize(
+      isGreenEnergy: Boolean,
+      energySources: Option[Iterable[EnergySource]],
+      environImpact: Option[Iterable[EnvironmentalImpact]],
+      supplierName: Option[String] = None,
+      energyProductName: Option[String] = None) =
+      new EnergyMix(
+        isGreenEnergy,
+        energySources getOrElse Nil,
+        environImpact getOrElse Nil,
+        supplierName,
+        energyProductName
+      )
+  }
+
   case class RegularHours(
     weekday: Int,
     periodBegin: String,
@@ -151,6 +214,19 @@ object Locations {
       "Opening hours need to be either 24/7 or have non-empty regular_hours")
   }
 
+  object Hours {
+    private[v2_1] def deserialize(
+      twentyfourseven: Boolean,
+      regularHours: Option[Iterable[RegularHours]],
+      exceptionalOpenings: Option[Iterable[ExceptionalPeriod]],
+      exceptionalClosings: Option[Iterable[ExceptionalPeriod]]
+    ) = new Hours(
+      twentyfourseven,
+      regularHours getOrElse Nil,
+      exceptionalOpenings getOrElse Nil,
+      exceptionalClosings getOrElse Nil
+    )
+  }
 
   case class Operator(
     identifier: Option[String], // unique identifier of the operator
@@ -233,6 +309,38 @@ object Locations {
     images: Iterable[Image] = Nil
     ){
     require(connectors.nonEmpty, "Iterable of connector can't be empty!")
+  }
+
+  object Evse {
+    private[v2_1] def deserialize(
+      uid: String,
+      lastUpdated: DateTime,
+      status: ConnectorStatus,
+      connectors: Option[Iterable[Connector]],
+      statusSchedule: Option[Iterable[StatusSchedule]],
+      capabilities: Option[Iterable[Capability]],
+      evseId: Option[String],
+      floorLevel:	Option[String],
+      coordinates:	Option[GeoLocation],
+      physicalReference:	Option[String],
+      directions: Option[Iterable[DisplayText]],
+      parkingRestrictions:	Option[Iterable[ParkingRestriction]],
+      images: Option[Iterable[Image]]
+    ) = new Evse(
+      uid,
+      lastUpdated,
+      status,
+      connectors getOrElse Nil,
+      statusSchedule getOrElse Nil,
+      capabilities getOrElse Nil,
+      evseId,
+      floorLevel,
+      coordinates,
+      physicalReference,
+      directions getOrElse Nil,
+      parkingRestrictions getOrElse Nil,
+      images getOrElse Nil
+    )
   }
 
   case class EvsePatch(

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tokens.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tokens.scala
@@ -55,6 +55,18 @@ object Tokens {
     connectorIds: Iterable[String] = Nil
   )
 
+  object LocationReferences {
+    private[v2_1] def deserialize(
+      locationId: String,
+      evseUids: Option[Iterable[String]],
+      connectorIds: Option[Iterable[String]]
+    ) = new LocationReferences(
+      locationId,
+      evseUids getOrElse Nil,
+      connectorIds getOrElse Nil
+    )
+  }
+
   sealed abstract class Allowed(val name: String) extends Nameable
   object Allowed extends Enumerable[Allowed] {
     case object Allowed extends Allowed("ALLOWED")


### PR DESCRIPTION
The OCPI spec says that missing array fields are to be interpreted as empty arrays.