### PR TITLE
require non-empty IDs

### DIFF
--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Cdrs.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Cdrs.scala
@@ -52,6 +52,7 @@ object Cdrs {
 
     def apply(value: String): CdrId = {
       require(value.length <= 36, "Cdr Id must be 36 characters or less")
+      require(value.nonEmpty, "Cdr Id cannot be an empty string")
       new CdrIdImpl(value)
     }
 

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
@@ -16,6 +16,7 @@ object Locations {
 
     def apply(value: String): LocationId = {
       require(value.length <= 39, "Location Id must be 39 characters or less")
+      require(value.nonEmpty, "Location Id cannot be an empty string")
       LocationIdImpl(value)
     }
 
@@ -218,6 +219,7 @@ object Locations {
 
     def apply(value: String): ConnectorId = {
       require(value.length <= 36, "Connector Id must be 36 characters or less")
+      require(value.nonEmpty, "Token Id cannot be an empty string")
       ConnectorIdImpl(value)
     }
 
@@ -285,6 +287,7 @@ object Locations {
 
     def apply(value: String): EvseUid = {
       require(value.length <= 39, "Evse Uid must be 39 characters or less")
+      require(value.nonEmpty, "Token Id cannot be an empty string")
       EvseUidImpl(value)
     }
 

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Sessions.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Sessions.scala
@@ -19,6 +19,7 @@ object Sessions {
 
     def apply(value: String): SessionId = {
       require(value.length <= 36, "Session Id must be 36 characters or less")
+      require(value.nonEmpty, "Session Id cannot be an empty string")
       SessionIdImpl(value)
     }
 

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tariffs.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tariffs.scala
@@ -63,6 +63,7 @@ object Tariffs {
 
     def apply(value: String): TariffId = {
       require(value.length <= 36, "Tariff Id must be 36 characters or less")
+      require(value.nonEmpty, "Tariff Id cannot be an empty string")
       TariffIdImpl(value)
     }
 

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tokens.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Tokens.scala
@@ -33,6 +33,7 @@ object Tokens {
 
     def apply(value: String): TokenUid = {
       require(value.length <= 36, "Token Uid must be 36 characters or less")
+      require(value.nonEmpty, "Token Id cannot be an empty string")
       TokenUidImpl(value)
     }
 
@@ -48,6 +49,7 @@ object Tokens {
 
     def apply(value: String): AuthId = {
       require(value.length <= 36, "Auth Id must be 36 characters or less")
+      require(value.nonEmpty, "Auth Id cannot be an empty string")
       AuthIdImpl(value)
     }
 


### PR DESCRIPTION
we require a length <= 36 chars as per the specs but we allow empty strings which is an implicit requirement