### PR TITLE
Fix order of path and method in MspTokensRoute

### DIFF
--- a/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensRoute.scala
+++ b/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensRoute.scala
@@ -70,8 +70,8 @@ class MspTokensRoute private[ocpi](
   )(
     implicit ec: ExecutionContext
   ): Route =
-    get {
-      pathEndOrSingleSlash {
+    pathEndOrSingleSlash {
+      get {
         paged { (pager: Pager, dateFrom: Option[ZonedDateTime], dateTo: Option[ZonedDateTime]) =>
           onSuccess(service.tokens(apiUser, pager, dateFrom, dateTo)) { pagTokens =>
             respondWithPaginationHeaders(pager, pagTokens) {


### PR DESCRIPTION
This is important to show the right rejection message to the caller