### PR TITLE
Allow routes that return paged data to override the scheme used in th…

### DIFF
--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedRouteSpec.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedRouteSpec.scala
@@ -107,6 +107,28 @@ class PaginatedRouteSpec extends Specification with Specs2RouteTest {
         }
       }
     }
+
+    "allow override of scheme in next link" in new TestScope {
+      override def linkHeaderScheme = Some("fish")
+
+      val testRoute =
+        get {
+          pathEndOrSingleSlash {
+            paged { (pager: Pager, _: Option[ZonedDateTime], _: Option[ZonedDateTime]) =>
+              respondWithPaginationHeaders(pager, PaginatedResult((1 to 5).map(_.toString), 100)) {
+                complete("OK")
+              }
+            }
+          }
+        }
+
+      Get("?horses=neigh&sheep=baa") ~> testRoute ~> check {
+        response.header[Link].map(_.values) must beLike {
+          case Some(List(lv)) =>
+            lv.uri.scheme mustEqual "fish"
+        }
+      }
+    }
   }
 
   trait TestScope extends Scope with PaginatedRoute {

--- a/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensRoute.scala
+++ b/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensRoute.scala
@@ -20,19 +20,21 @@ object MspTokensRoute {
   def apply(
     service: MspTokensService,
     DefaultLimit: Int = 1000,
-    MaxLimit: Int = 1000
+    MaxLimit: Int = 1000,
+    linkHeaderScheme: Option[String] = None
   )(
     implicit pagTokensM: SuccessRespMar[Iterable[Token]],
     authM: SuccessRespMar[AuthorizationInfo],
     errorM: ErrRespMar,
     locationReferencesU: FromEntityUnmarshaller[LocationReferences]
-  ) = new MspTokensRoute(service, DefaultLimit, MaxLimit)
+  ) = new MspTokensRoute(service, DefaultLimit, MaxLimit, linkHeaderScheme)
 }
 
 class MspTokensRoute private[ocpi](
   service: MspTokensService,
   val DefaultLimit: Int,
-  val MaxLimit: Int
+  val MaxLimit: Int,
+  override val linkHeaderScheme: Option[String] = None
 )(
   implicit pagTokensM: SuccessRespMar[Iterable[Token]],
   authM: SuccessRespMar[AuthorizationInfo],


### PR DESCRIPTION
…e link header

This is useful for instance where the service is behind a load balancer and receives requests as http, whereas the link header should be https