### PR TITLE
Fix scala 2.11 compilation issues

### DIFF
--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TariffsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TariffsJsonProtocol.scala
@@ -6,6 +6,7 @@ import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder, HCursor}
 import CommonJsonProtocol._
 import LocationsJsonProtocol._
+import io.circe.Decoder.Result
 
 trait TariffsJsonProtocol {
 
@@ -20,13 +21,15 @@ trait TariffsJsonProtocol {
   implicit val tariffRestrictionsD: Decoder[TariffRestrictions] = deriveDecoder
 
   implicit val tariffElementE: Encoder[TariffElement] = deriveEncoder
-  implicit val tariffElementD: Decoder[TariffElement] = (c: HCursor) =>
-    for {
+
+  implicit val tariffElementD: Decoder[TariffElement] = new Decoder[TariffElement] {
+    final def apply(c: HCursor): Result[TariffElement] = for {
       pcs <- c.downField("price_components").as[Seq[PriceComponent]]
       restr <- c.downField("restrictions").as[Option[TariffRestrictions]]
     } yield {
       TariffElement(pcs, restr)
     }
+  }
 
   implicit val tariffE: Encoder[Tariff] = deriveEncoder
   implicit val tariffD: Decoder[Tariff] = deriveDecoder

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTariffsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTariffsSpec.scala
@@ -136,7 +136,7 @@ trait GenericTariffsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
       id = TariffId("12"),
       currency = CurrencyCode("EUR"),
       tariffAltUrl = Some(Url("https://company.com/tariffs/12")),
-      elements = List(TariffElement(List()) ),
+      elements = Vector(TariffElement(List(PriceComponent(Time,6, 1), PriceComponent(Time,6, 0), PriceComponent(Time,6, 0)))),
       energyMix = None,
       lastUpdated = ZonedDateTime.of(2015, 6, 29, 20, 39, 9, 0, ZoneId.of("Z"))
     )
@@ -151,15 +151,15 @@ trait GenericTariffsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
       |	"tariff_alt_url": "https://company.com/tariffs/12",
       |	"elements": [{
       |		"price_components": [{
-      |			"type": "SESSION_TIME",
+      |			"type": "TIME",
       |			"price": 6.00,
       |			"step_size": 1
       |		},{
-      |			"type": "MIN",
+      |			"type": "TIME",
       |			"price": 6.00,
       |			"step_size": 0
       |		},{
-      |			"type": "MAX",
+      |			"type": "TIME",
       |			"price": 6.00,
       |			"step_size": 0
       |		}]
@@ -167,5 +167,8 @@ trait GenericTariffsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
       |	"last_updated": "2015-06-29T20:39:09Z"
       |}
     """.stripMargin
+
+  // Tariff(12,Impl(EUR),None,Some(https://company.com/tariffs/12),Vector(TariffElement(List(PriceComponent(TIME,6,1), PriceComponent(TIME,6,0), PriceComponent(TIME,6,0)),None)),None,2015-06-29T20:39:09Z) !=
+  // Tariff(12,Impl(EUR),None,Some(https://company.com/tariffs/12),List(TariffElement(List(),None)),None,2015-06-29T20:39:09Z)
 
 }

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/TariffsSpec.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/TariffsSpec.scala
@@ -8,7 +8,7 @@ class TariffsSpec extends GenericTariffsSpec[JsValue, JsonReader, JsonWriter] wi
   import TariffsJsonProtocol._
 
   "Spray Json TariffsJsonProtocol" should {
-//    runTests()
+    runTests()
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-CHARGEPOINT-INC-RELEASE"
+version in ThisBuild := "1.0.4-CHARGEPOINT-INC-RELEASE"


### PR DESCRIPTION
Removes usage of [SAM](https://www.scala-lang.org/news/2.12.0/#lambda-syntax-for-sam-types) types to fix compilation issues on `Scala v2.11`. SAM types are available in `Scala v2.11` after enabling the `-Xexperimental` flag but that might open the door for some unexpected surprises.

