### PR TITLE
Add support for CDR MSP modules routes without Global Party match

### DIFF
--- a/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRoute.scala
+++ b/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRoute.scala
@@ -63,21 +63,19 @@ class MspCdrsRoute private[ocpi](
   )(
     implicit executionContext: ExecutionContext
   ) = {
-    authPathPrefixGlobalPartyIdEquality(apiUser) {
-      (post & pathEndOrSingleSlash) {
-        entity(as[Cdr]) { cdr =>
-          complete {
-            service.createCdr(apiUser, cdr).mapRight { _ =>
-              (Created, SuccessResp(GenericSuccess))
-            }
+    (post & pathEndOrSingleSlash) {
+      entity(as[Cdr]) { cdr =>
+        complete {
+          service.createCdr(apiUser, cdr).mapRight { _ =>
+            (Created, SuccessResp(GenericSuccess))
           }
         }
-      } ~
-      (get & pathPrefix(CdrIdSegment) & pathEndOrSingleSlash) { cdrId =>
-        complete {
-          service.cdr(apiUser, cdrId).mapRight { cdr =>
-            SuccessResp(GenericSuccess, data = cdr)
-          }
+      }
+    } ~
+    (get & pathPrefix(CdrIdSegment) & pathEndOrSingleSlash) { cdrId =>
+      complete {
+        service.cdr(apiUser, cdrId).mapRight { cdr =>
+          SuccessResp(GenericSuccess, data = cdr)
         }
       }
     }

--- a/endpoints-msp-cdrs/src/test/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRouteSpec.scala
+++ b/endpoints-msp-cdrs/src/test/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRouteSpec.scala
@@ -24,7 +24,7 @@ class MspCdrsRouteSpec extends Specification with Specs2RouteTest with Mockito {
   "MspCdrsRoute" should {
     "return an existing Cdr" in new TestScope {
       service.cdr(apiUser, cdr.id) returns Future(cdr.asRight)
-      Get("/NL/TNM/12345") ~> route(apiUser) ~> check {
+      Get("/12345") ~> route(apiUser) ~> check {
         header[Link] must beNone
         there was one(service).cdr(apiUser, cdr.id)
         val res = entityAs[SuccessResp[Cdr]]
@@ -35,7 +35,7 @@ class MspCdrsRouteSpec extends Specification with Specs2RouteTest with Mockito {
     "handle NotFound failure" in new TestScope {
       service.cdr(apiUser, CdrId("does-not-exist")) returns Future(CdrNotFound().asLeft)
 
-      Get("/NL/TNM/does-not-exist") ~> route(apiUser) ~> check {
+      Get("/does-not-exist") ~> route(apiUser) ~> check {
         there was one(service).cdr(apiUser, CdrId("does-not-exist"))
         status mustEqual StatusCodes.NotFound
       }
@@ -44,7 +44,7 @@ class MspCdrsRouteSpec extends Specification with Specs2RouteTest with Mockito {
     "allow posting new cdr" in new TestScope {
       service.createCdr(apiUser, cdr) returns Future(().asRight)
 
-      Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
+      Post("/", cdr) ~> route(apiUser) ~> check {
         there was one(service).createCdr(apiUser, cdr)
         status mustEqual StatusCodes.Created
       }
@@ -53,7 +53,7 @@ class MspCdrsRouteSpec extends Specification with Specs2RouteTest with Mockito {
     "not allow updating cdr" in new TestScope {
       service.createCdr(apiUser, cdr) returns Future(CdrCreationFailed().asLeft)
 
-      Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
+      Post("/", cdr) ~> route(apiUser) ~> check {
         there was one(service).createCdr(apiUser, cdr)
         status mustEqual StatusCodes.OK
       }

--- a/endpoints-msp-cdrs/src/test/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRouteSpec.scala
+++ b/endpoints-msp-cdrs/src/test/scala/com/thenewmotion/ocpi/cdrs/MspCdrsRouteSpec.scala
@@ -21,82 +21,41 @@ import scala.concurrent.Future
 
 class MspCdrsRouteSpec extends Specification with Specs2RouteTest with Mockito {
 
-  "MspCdrsRoute" >> {
-    "with Global Party match" should {
-      "return an existing Cdr" in new TestScope {
-        service.cdr(apiUser, cdr.id) returns Future(cdr.asRight)
-        Get("/NL/TNM/12345") ~> route(apiUser) ~> check {
-          header[Link] must beNone
-          there was one(service).cdr(apiUser, cdr.id)
-          val res = entityAs[SuccessResp[Cdr]]
-          res.data mustEqual cdr
-        }
-      }
-
-      "handle NotFound failure" in new TestScope {
-        service.cdr(apiUser, CdrId("does-not-exist")) returns Future(CdrNotFound().asLeft)
-
-        Get("/NL/TNM/does-not-exist") ~> route(apiUser) ~> check {
-          there was one(service).cdr(apiUser, CdrId("does-not-exist"))
-          status mustEqual StatusCodes.NotFound
-        }
-      }
-
-      "allow posting new cdr" in new TestScope {
-        service.createCdr(apiUser, cdr) returns Future(().asRight)
-
-        Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
-          there was one(service).createCdr(apiUser, cdr)
-          status mustEqual StatusCodes.Created
-        }
-      }
-
-      "not allow updating cdr" in new TestScope {
-        service.createCdr(apiUser, cdr) returns Future(CdrCreationFailed().asLeft)
-
-        Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
-          there was one(service).createCdr(apiUser, cdr)
-          status mustEqual StatusCodes.OK
-        }
+  "MspCdrsRoute" should {
+    "return an existing Cdr" in new TestScope {
+      service.cdr(apiUser, cdr.id) returns Future(cdr.asRight)
+      Get("/NL/TNM/12345") ~> route(apiUser) ~> check {
+        header[Link] must beNone
+        there was one(service).cdr(apiUser, cdr.id)
+        val res = entityAs[SuccessResp[Cdr]]
+        res.data mustEqual cdr
       }
     }
 
-    "without Global Party match" should {
-      "return an existing Cdr" in new TestScope {
-        service.cdr(apiUser, cdr.id) returns Future(cdr.asRight)
-        Get("/12345") ~> route.applyWithoutGlobalPartyMatch(apiUser) ~> check {
-          header[Link] must beNone
-          there was one(service).cdr(apiUser, cdr.id)
-          val res = entityAs[SuccessResp[Cdr]]
-          res.data mustEqual cdr
-        }
+    "handle NotFound failure" in new TestScope {
+      service.cdr(apiUser, CdrId("does-not-exist")) returns Future(CdrNotFound().asLeft)
+
+      Get("/NL/TNM/does-not-exist") ~> route(apiUser) ~> check {
+        there was one(service).cdr(apiUser, CdrId("does-not-exist"))
+        status mustEqual StatusCodes.NotFound
       }
+    }
 
-      "handle NotFound failure" in new TestScope {
-        service.cdr(apiUser, CdrId("does-not-exist")) returns Future(CdrNotFound().asLeft)
+    "allow posting new cdr" in new TestScope {
+      service.createCdr(apiUser, cdr) returns Future(().asRight)
 
-        Get("/does-not-exist") ~> route.applyWithoutGlobalPartyMatch(apiUser) ~> check {
-          there was one(service).cdr(apiUser, CdrId("does-not-exist"))
-          status mustEqual StatusCodes.NotFound
-        }
+      Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
+        there was one(service).createCdr(apiUser, cdr)
+        status mustEqual StatusCodes.Created
       }
+    }
 
-      "allow posting new cdr" in new TestScope {
-        service.createCdr(apiUser, cdr) returns Future(().asRight)
+    "not allow updating cdr" in new TestScope {
+      service.createCdr(apiUser, cdr) returns Future(CdrCreationFailed().asLeft)
 
-        Post("/", cdr) ~> route.applyWithoutGlobalPartyMatch(apiUser) ~> check {
-          there was one(service).createCdr(apiUser, cdr)
-          status mustEqual StatusCodes.Created
-        }
-      }
-
-      "not allow updating cdr" in new TestScope {
-        service.createCdr(apiUser, cdr) returns Future(CdrCreationFailed().asLeft)
-
-        Post("/", cdr) ~> route.applyWithoutGlobalPartyMatch(apiUser) ~> check {
-          there was one(service).createCdr(apiUser, cdr)
-          status mustEqual StatusCodes.OK
-        }
+      Post("/NL/TNM", cdr) ~> route(apiUser) ~> check {
+        there was one(service).createCdr(apiUser, cdr)
+        status mustEqual StatusCodes.OK
       }
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.5-CHARGEPOINT-INC-RELEASE"
+version in ThisBuild := "1.0.4-CHARGEPOINT-INC-RELEASE"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.4-CHARGEPOINT-INC-RELEASE"
+version in ThisBuild := "1.0.5-CHARGEPOINT-INC-RELEASE"


### PR DESCRIPTION
Right now **CDR**_s_ routes living in `ocpi-endpoints-msp-cdrs` module require sending the Global Party identifiers as URL segments like this:

```
http://localhost:8019/ocpi/msp/2.1/cdrs/NL/ILI
```

where `NL` is the country code and `ILI` the Party identifier. 

However, many **MSP**_s_ use the endpoints without the `/<country-code>/<party-id>` segment. Even the **OCPI** documentation has [lots of examples ](https://github.com/ocpi/ocpi/blob/master/mod_cdrs.asciidoc#12-interfaces-and-endpoints) excluding the Global Party segments.

This PR adds support for CDR MSP routes without Global Party match. That way we can expose **MSP CDR**_s_ endpoints like this:

```
http://localhost:8019/ocpi/msp/2.1/cdrs/NL/ILI
```

