### PR TITLE
Allow empty connectors list in EVSE

### DIFF
--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
@@ -35,7 +35,7 @@ object PaginatedSource extends AuthorizedRequests with EitherUnmarshalling with 
   ): Future[Either[ErrorResp, (PagedResp[T], Option[Uri])]] =
     (for {
       response <- result(requestWithAuth(http, req, auth).map(_.asRight))
-      success <- result(Unmarshal(response).to[Either[ErrorResp, (PagedResp[T], Option[Uri])]])
+      success <- result(Unmarshal(response).to[ErrorRespOr[(PagedResp[T], Option[Uri])]])
     } yield success).value.recoverWith {
       case NonFatal(ex) => Future.failed(PaginationException(req.uri, ex))
     }

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/v2_1/Locations.scala
@@ -328,9 +328,7 @@ object Locations {
     directions: Iterable[DisplayText] = Nil,
     parkingRestrictions: Iterable[ParkingRestriction] = Nil,
     images: Iterable[Image] = Nil
-  ) extends BaseEvse[Full] {
-    require(connectors.nonEmpty, "Evse must have at least one connector")
-  }
+  ) extends BaseEvse[Full]
 
   case class EvsePatch(
     lastUpdated: Option[ZonedDateTime] = None,


### PR DESCRIPTION
We can filter out locations without EVSE close to the business logic. 
Also from the propositions-as-types POV, a `NonEmptyList` should have been used instead to keep up with the type promised. But we keep things simple and allow what the type allows