### PR TITLE
Fix parsing of time without leading zeros

### DIFF
--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
@@ -55,6 +55,10 @@ trait GenericCommonTypesSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] exte
 
     "Time" should {
       testPair(LocalTime.of(13, 25), jsonStringToJson("13:25"))
+
+      "parse time without leading zero" in {
+        jsonToObj[LocalTime](jsonStringToJson("5:8")) === LocalTime.of(5, 8)
+      }
     }
 
     "Date" should {

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/dateTimeParsing.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/dateTimeParsing.scala
@@ -33,10 +33,10 @@ object ZonedDateTimeParser {
 object LocalTimeParser {
   private val formatter: DateTimeFormatter =
     new DateTimeFormatterBuilder()
+      .parseLenient()
       .appendValue(HOUR_OF_DAY, 2)
       .appendLiteral(':')
       .appendValue(MINUTE_OF_HOUR, 2)
-      .parseLenient()
       .toFormatter
 
   def format(dt: LocalTime): String = formatter.format(dt)


### PR DESCRIPTION
 The time parser is stateful, so the order in the builder is important.