### PR TITLE
allow passing of page limit from client code

### DIFF
--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/AuthorizedRequests.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/AuthorizedRequests.scala
@@ -2,8 +2,8 @@ package com.thenewmotion.ocpi.common
 
 import scala.concurrent.{ExecutionContext, Future}
 import akka.http.scaladsl.HttpExt
-import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials, Location, RawHeader}
-import akka.http.scaladsl.model.{HttpHeader, HttpMessage, HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.headers.{GenericHttpCredentials, Location}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.Materializer
 import com.thenewmotion.ocpi.Logger
 import com.thenewmotion.ocpi.msgs.AuthToken

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/EitherUnmarshalling.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/EitherUnmarshalling.scala
@@ -32,9 +32,13 @@ trait EitherUnmarshalling {
       }
 
       for {
-        e <- value.httpEntity.toStrict(10.seconds)
+        e <- value.httpEntity.toStrict(EitherUnmarshalling.Timeout)
         res <- right(e).recoverWith(fallbackLeft(e))
       } yield res
     }
 
+}
+
+object EitherUnmarshalling {
+  val Timeout: FiniteDuration = 20.seconds
 }

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiClient.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiClient.scala
@@ -45,7 +45,7 @@ private[common] case class OcpiClientException(errorResp: ErrorResp)
 case class FailedRequestException(request: HttpRequest, response: HttpResponse, cause: Throwable)
   extends Exception("Failed to get response to OCPI request", cause)
 
-abstract class OcpiClient(MaxNumItems: Int = 100)(implicit http: HttpExt)
+abstract class OcpiClient(implicit http: HttpExt)
   extends AuthorizedRequests with EitherUnmarshalling with OcpiResponseUnmarshalling {
 
   protected def singleRequestRawT[T : ClassTag](
@@ -78,7 +78,7 @@ abstract class OcpiClient(MaxNumItems: Int = 100)(implicit http: HttpExt)
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
     dateTo: Option[ZonedDateTime] = None,
-    limit: Int = MaxNumItems
+    limit: Int
   )(
     implicit ec: ExecutionContext, mat: Materializer, successU: PagedRespUnMar[T], errorU: ErrRespUnMar
   ): Future[ErrorRespOr[Iterable[T]]] =
@@ -87,4 +87,8 @@ abstract class OcpiClient(MaxNumItems: Int = 100)(implicit http: HttpExt)
     }.recover {
       case OcpiClientException(errorResp) => errorResp.asLeft
     }
+}
+
+object OcpiClient {
+  val DefaultPageLimit: Int = PaginatedSource.DefaultPageLimit
 }

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedSource.scala
@@ -23,6 +23,8 @@ case class PaginationException(uri: Uri, cause: Throwable)
 
 object PaginatedSource extends AuthorizedRequests with EitherUnmarshalling with OcpiResponseUnmarshalling {
 
+  val DefaultPageLimit = 100
+
   private def singleRequestWithNextLink[T](
     http: HttpExt,
     req: HttpRequest,
@@ -46,12 +48,12 @@ object PaginatedSource extends AuthorizedRequests with EitherUnmarshalling with 
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
     dateTo: Option[ZonedDateTime] = None,
-    limit: Int = 100
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(implicit ec: ExecutionContext, mat: Materializer,
     successU: PagedRespUnMar[T], errorU: ErrRespUnMar): Source[T, NotUsed] = {
     val query = Query(Map(
       "offset" -> "0",
-      "limit" -> limit.toString) ++
+      "limit" -> pageLimit.toString) ++
       dateFrom.map("date_from" -> format(_)) ++
       dateTo.map("date_to" -> format(_))
     )

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedSourceSpec.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedSourceSpec.scala
@@ -60,7 +60,7 @@ class PaginatedSourceSpec(implicit ee: ExecutionEnv) extends Specification with 
 
       val probe = TestProbe()
 
-      PaginatedSource[TestData](http, dataUrl, AuthToken[Ours]("auth"), limit = 2)
+      PaginatedSource[TestData](http, dataUrl, AuthToken[Ours]("auth"), pageLimit = 2)
         .runWith(TestSink.probe[TestData])
         .request(5)
         .expectNext(TestData("DATA1"), TestData("DATA2"), TestData("DATA3"), TestData("DATA4"))
@@ -92,7 +92,7 @@ class PaginatedSourceSpec(implicit ee: ExecutionEnv) extends Specification with 
 
       val probe = TestProbe()
 
-      PaginatedSource[TestData](http, dataUrl, AuthToken[Ours]("auth"), limit = 2)
+      PaginatedSource[TestData](http, dataUrl, AuthToken[Ours]("auth"), pageLimit = 2)
         .runWith(TestSink.probe[TestData])
         .request(5)
         .expectNext(TestData("DATA1"), TestData("DATA2"))

--- a/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
+++ b/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
@@ -22,7 +22,8 @@ class TokensClient(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Either[ErrorResp, Iterable[Token]]] =
-    traversePaginatedResource[Token](uri, auth, dateFrom, dateTo)
+    traversePaginatedResource[Token](uri, auth, dateFrom, dateTo, pageLimit)
 }

--- a/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
+++ b/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
@@ -25,22 +25,24 @@ class CdrsClient(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Future[ErrorRespOr[Iterable[Cdr]]] =
-    traversePaginatedResource[Cdr](uri, auth, dateFrom, dateTo)
+    traversePaginatedResource[Cdr](uri, auth, dateFrom, dateTo, pageLimit)
 
   def cdrsSource(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Source[Cdr, NotUsed] =
-    PaginatedSource[Cdr](http, uri, auth, dateFrom, dateTo)
+    PaginatedSource[Cdr](http, uri, auth, dateFrom, dateTo, pageLimit)
 
 }

--- a/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
+++ b/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
@@ -25,22 +25,24 @@ class LocationsClient(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Future[ErrorRespOr[Iterable[Location]]] =
-    traversePaginatedResource[Location](uri, auth, dateFrom, dateTo)
+    traversePaginatedResource[Location](uri, auth, dateFrom, dateTo, pageLimit)
 
   def locationsSource(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: Option[ZonedDateTime] = None,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Source[Location, NotUsed] =
-    PaginatedSource[Location](http, uri, auth, dateFrom, dateTo)
+    PaginatedSource[Location](http, uri, auth, dateFrom, dateTo, pageLimit)
 
 }

--- a/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
+++ b/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
@@ -24,22 +24,24 @@ class SessionsClient(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: ZonedDateTime,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Future[ErrorRespOr[Iterable[Session]]] =
-    traversePaginatedResource[Session](uri, auth, Some(dateFrom), dateTo)
+    traversePaginatedResource[Session](uri, auth, Some(dateFrom), dateTo, pageLimit)
 
   def sessionsSource(
     uri: Uri,
     auth: AuthToken[Ours],
     dateFrom: ZonedDateTime,
-    dateTo: Option[ZonedDateTime] = None
+    dateTo: Option[ZonedDateTime] = None,
+    pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
     mat: Materializer
   ): Source[Session, NotUsed] =
-    PaginatedSource[Session](http, uri, auth, Some(dateFrom), dateTo)
+    PaginatedSource[Session](http, uri, auth, Some(dateFrom), dateTo, pageLimit)
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.4-SNAPSHOT"
+version in ThisBuild := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
right now we're tied to the hardcoded magic number page size of `100`. That's completely unnecessary. Even large objects such as locations amount to 2kB. We can easily handle a page with 1000 of those. 
This PR will make it possible for client code to pick higher page limits if needed. Servers typically take the `min(clientLimit, serverLimit)` and don't throw errors so clients are safe to experiment with higher limits.