### PR TITLE
Add a way to parse responses with no `.data` field to a `PagedResp[T]`

### DIFF
--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
@@ -76,11 +76,20 @@ trait CommonJsonProtocol {
         SuccessResp(statusCode, statusMsg, timestamp)
     }
 
+  def successPagedRespWithoutDataD[T]: Decoder[SuccessResp[Iterable[T]]] =
+    implicitly[Decoder[SuccessResp[Unit]]].map(_.copy(data = Iterable.empty[T]))
+
+  def successPagedRespWithData[T: Decoder]: Decoder[SuccessResp[Iterable[T]]] = successRespD[Iterable[T]]
+
+  def successPagedResp[T: Decoder]: Decoder[SuccessResp[Iterable[T]]] =
+    successPagedRespWithData[T].handleErrorWith(_ => successPagedRespWithoutDataD[T])
+
   implicit val errorRespE: Encoder[ErrorResp] = deriveEncoder
   implicit val errorRespD: Decoder[ErrorResp] = deriveDecoder
 
   implicit def successRespE[D : Encoder]: Encoder[SuccessResp[D]] = deriveEncoder
   implicit def successRespD[D : Decoder]: Decoder[SuccessResp[D]] = deriveDecoder
+
 
   implicit val displayTextE: Encoder[DisplayText] = deriveEncoder
   implicit val displayTextD: Decoder[DisplayText] = deriveDecoder

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
@@ -6,8 +6,10 @@ import cats.syntax.either._
 import OcpiStatusCode.SuccessCode
 import v2_1.CommonTypes._
 import com.thenewmotion.ocpi._
+import io.circe.CursorOp.DownField
 import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
+
 import scala.reflect.{ClassTag, classTag}
 import shapeless._
 
@@ -82,7 +84,9 @@ trait CommonJsonProtocol {
   def successPagedRespWithData[T: Decoder]: Decoder[SuccessResp[Iterable[T]]] = successRespD[Iterable[T]]
 
   def successPagedResp[T: Decoder]: Decoder[SuccessResp[Iterable[T]]] =
-    successPagedRespWithData[T].handleErrorWith(_ => successPagedRespWithoutDataD[T])
+    successPagedRespWithData[T].handleErrorWith {
+      case e if e.history == List(DownField("data")) => successPagedRespWithoutDataD[T]
+    }
 
   implicit val errorRespE: Encoder[ErrorResp] = deriveEncoder
   implicit val errorRespD: Decoder[ErrorResp] = deriveDecoder

--- a/msgs-circe/src/test/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonTypesSpec.scala
+++ b/msgs-circe/src/test/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonTypesSpec.scala
@@ -3,10 +3,10 @@ package com.thenewmotion.ocpi.msgs.circe.v2_1
 import com.thenewmotion.ocpi.msgs.v2_1.GenericCommonTypesSpec
 import io.circe.{Decoder, Encoder, Json}
 
-class CommonTypesSpecs extends GenericCommonTypesSpec[Json, Decoder, Encoder] with CirceJsonSpec {
+class CommonTypesSpec extends GenericCommonTypesSpec[Json, Decoder, Encoder] with CirceJsonSpec {
   import CommonJsonProtocol._
 
   "Circe DefaultJsonProtocol" should {
-    runTests()
+    runTests(successPagedResp)
   }
 }

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
@@ -58,6 +58,8 @@ trait GenericCommonTypesSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] exte
         val resp2 = jsonToObj(parse(successRespJson3))(successPagedRespD)
         resp2 must haveClass[PagedResp[Int]]
         resp2.copy(data = resp2.data.toList) === successResp3.copy(data = successResp3.data.toList)
+
+        jsonToObj(parse(successRespJson4))(successPagedRespD) must throwA
       }
     }
 
@@ -112,6 +114,16 @@ trait GenericCommonTypesSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] exte
        |  "status_message" : "It worked!",
        |  "timestamp": "2010-01-01T00:00:00Z",
        |  "data": [42, 43]
+       |}
+ """.stripMargin
+
+  val successRespJson4: String =
+    s"""
+       |{
+       |  "status_code" : 1000,
+       |  "status_message" : "It worked!",
+       |  "timestamp": "2010-01-01T00:00:00Z",
+       |  "data": [42, "Kaboom !!!"]
        |}
  """.stripMargin
 

--- a/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
+++ b/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
@@ -2,12 +2,13 @@ package com.thenewmotion.ocpi.msgs
 package sprayjson.v2_1
 
 import java.time.{Duration, LocalDate, LocalTime, ZonedDateTime}
-
 import OcpiStatusCode.SuccessCode
 import sprayjson.SimpleStringEnumSerializer._
 import v2_1.CommonTypes._
 import com.thenewmotion.ocpi.{LocalDateParser, LocalTimeParser, ZonedDateTimeParser}
-import spray.json.{JsNumber, JsString, JsValue, JsonFormat, deserializationError}
+import spray.json.{JsNumber, JsString, JsValue, JsonFormat, JsonReader, RootJsonFormat, RootJsonReader, deserializationError}
+
+import scala.util.Try
 
 trait DefaultJsonProtocol extends spray.json.DefaultJsonProtocol {
 
@@ -127,7 +128,16 @@ trait DefaultJsonProtocol extends spray.json.DefaultJsonProtocol {
     }
   }
 
-  implicit val displayTextFormat = jsonFormat2(DisplayText)
+  implicit val displayTextFormat: RootJsonFormat[DisplayText] = jsonFormat2(DisplayText)
+
+  def successRespReader[D: JsonReader]: RootJsonReader[SuccessResp[D]] = ???
+
+  def successPagedRes[T: JsonFormat]: RootJsonReader[SuccessResp[Iterable[T]]] =
+    js => {
+      val withData = successRespFormat[Iterable[T]].read _
+      val withoutData = successRespUnitFormat.read(_: JsValue).copy(data = Iterable.empty[T])
+      Try(withData(js)).recover { case _ => withoutData(js) }.get
+    }
 }
 
 object DefaultJsonProtocol extends DefaultJsonProtocol

--- a/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/CommonTypesSpec.scala
+++ b/msgs-spray-json/src/test/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/CommonTypesSpec.scala
@@ -8,6 +8,6 @@ class CommonTypesSpec extends GenericCommonTypesSpec[JsValue, JsonReader, JsonWr
   import DefaultJsonProtocol._
 
   "Spray DefaultJsonProtocol" should {
-    runTests()
+    runTests(successPagedRes)
   }
 }


### PR DESCRIPTION
According to protocol spec sender can omit `.data` field altogether when a list is expected but its empty (e.g. an empty list of locations)

Should sender chose to do so, trying to parse it to `SuccessResp[Unit]` fails. Recipient should parse it to `PagedResp[T]` instead.