### PR TITLE
migrate to cats-effect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ test-output/
 .classpath_nb
 
 #sbt
+.bsp
 .history
 .bsp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 dist: trusty
 scala:
-  - 2.12.8
+  - 2.12.12
+  - 2.13.4
 jdk:
   - oraclejdk8
 script: sbt ++$TRAVIS_SCALA_VERSION clean test

--- a/README.md
+++ b/README.md
@@ -49,7 +49,43 @@ Then in the route or client you want to use
 import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
 ```
 
+## cats-effect support
+To be able to pass IO as the effect type, import marshaller instances for it:
+
+`import com.thenewmotion.ocpi.common.HktMarshallableInstances._`
+
+
+
 # Changelog
+
+## 2.0.0-M1
+Migrate effect type to cats-effect IO.
+At the core, we still use akka-http for routes and clients so we need the typical akka implicits. 
+Stream sources are also still using akka-stream.
+But at the interface to the backend services implemented by the calling application code, IO (or ZIO) can be
+used to model effect types.
+
+In the following phases, we should migrate further to http4s, sttp (?) and fs2. 
+
+
+## 1.3.0
+- allow passing of page limit from client code
+- increase unmarshalling timeout to handle higher page sizes
+- handle omitted `.data` field (when a list is expected but its empty)
+
+## 1.2.3
+- fix parsing of time without leading zeros; 2nd try
+
+## 1.2.2
+- Don't log credentials during registration
+- fix parsing of time without leading zeros
+- handle missing `twentyfourseven` field in `hours` object 
+
+## 1.2.1
+Redact auth header before logging request
+
+## 1.2.0
+Update to Circe 0.12.3
 
 ## 1.0.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,8 @@ val `cats-effect` = Seq("org.typelevel" %% "cats-effect" % "2.1.4")
 val specs2 = {
   def module(name: String) = "org.specs2" %% s"specs2-$name" % "4.10.0" % "test"
   Seq(
-    module("core"), module("junit"), module("mock")
+    module("core"), module("junit"), module("mock"), module("cats"),
+    "com.codecommit" %% "cats-effect-testing-specs2" % "0.5.1" % Test
   )
 }
 
@@ -138,7 +139,7 @@ val `endpoints-common` = project
 
 val `endpoints-msp-locations` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-msp-locations",
@@ -148,7 +149,7 @@ val `endpoints-msp-locations` = project
 
 val `endpoints-msp-tokens` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-msp-tokens",
@@ -158,7 +159,7 @@ val `endpoints-msp-tokens` = project
 
 val `endpoints-msp-cdrs` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-msp-cdrs",
@@ -168,7 +169,7 @@ val `endpoints-msp-cdrs` = project
 
 val `endpoints-msp-commands` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-msp-commands",
@@ -178,7 +179,7 @@ val `endpoints-msp-commands` = project
 
 val `endpoints-msp-sessions` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-msp-sessions",
@@ -188,7 +189,7 @@ val `endpoints-msp-sessions` = project
 
 val `endpoints-cpo-locations` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-cpo-locations",
@@ -198,7 +199,7 @@ val `endpoints-cpo-locations` = project
 
 val `endpoints-cpo-tokens` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-cpo-tokens",
@@ -208,7 +209,7 @@ val `endpoints-cpo-tokens` = project
 
 val `endpoints-versions` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-versions",
@@ -218,7 +219,7 @@ val `endpoints-versions` = project
 
 val `endpoints-registration` = project
   .enablePlugins(OssLibPlugin)
-  .dependsOn(`endpoints-common`, `msgs-spray-json` % "test->test")
+  .dependsOn(`endpoints-common` % "compile->compile;test->test", `msgs-spray-json` % "test->test")
   .settings(
     commonSettings,
     name := "ocpi-endpoints-registration",

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,6 @@ val commonSettings = Seq(
     "-feature",             // warn about misused language features
     "-language:higherKinds",// allow higher kinded types without `import scala.language.higherKinds`
     "-Xlint",               // enable handy linter warnings
-    "-Ypartial-unification",
     "-language:postfixOps"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,18 @@ val `spray-json` = Seq("io.spray" %% "spray-json"             %   "1.3.5")
 
 val shapeless = Seq("com.chuusai" %% "shapeless" % "2.3.3")
 
-val `circe` = {
+val circe = {
   val version = "0.12.3"
   
   Seq(
     "io.circe" %% "circe-core" % version,
     "io.circe" %% "circe-generic-extras" % "0.12.2",
-    "io.circe" %% "circe-parser" % version % "test"
+    "io.circe" %% "circe-parser" % version
   )
+}
+
+val `akka-http-circe` = {
+  Seq("de.heikoseeberger" %% "akka-http-circe" % "1.29.1")
 }
 
 def akkaModule(name: String) = {
@@ -30,9 +34,10 @@ val akka =
     akkaModule("http")
   )
 
-val akkaHttpSprayJson = Seq(akkaModule("http-spray-json"))
+val `akka-http-spray-json` = Seq(akkaModule("http-spray-json"))
 
 val cats = Seq("org.typelevel" %% "cats-core" % "2.1.1")
+val `cats-effect` = Seq("org.typelevel" %% "cats-effect" % "2.1.4")
 
 val specs2 = {
   def module(name: String) = "org.specs2" %% s"specs2-$name" % "4.10.0" % "test"
@@ -41,26 +46,36 @@ val specs2 = {
   )
 }
 
-val akkaHttpTestKit = Seq(akkaModule("http-testkit") % "test")
-val akkaStreamTestKit = Seq(akkaModule("stream-testkit") % "test")
+val `akka-http-test-kit` = Seq(akkaModule("http-testkit") % "test")
+val `akka-stream-test-kit` = Seq(akkaModule("stream-testkit") % "test")
 
-val jsonLenses = Seq("net.virtual-void" %% "json-lenses" %  "0.6.2")
+val `json-lenses` = Seq("net.virtual-void" %% "json-lenses" %  "0.6.2")
 
 val commonSettings = Seq(
   organization := "com.thenewmotion.ocpi",
   licenses += ("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
   crossScalaVersions := List(tnm.ScalaVersion.prev, tnm.ScalaVersion.curr),
-  scalaVersion := tnm.ScalaVersion.prev
+  scalaVersion := tnm.ScalaVersion.prev,
+  scalacOptions ++= Seq(
+    "-encoding", "UTF-8",   // source files are in UTF-8
+    "-deprecation",         // warn about use of deprecated APIs
+    "-unchecked",           // warn about unchecked type parameters
+    "-feature",             // warn about misused language features
+    "-language:higherKinds",// allow higher kinded types without `import scala.language.higherKinds`
+    "-Xlint",               // enable handy linter warnings
+    "-Ypartial-unification",
+    "-language:postfixOps"
+  )
 )
 
-val `prelude` = project
+val prelude = project
   .enablePlugins(OssLibPlugin)
   .settings(
     commonSettings,
     name := "ocpi-prelude",
     description := "Definitions that are useful across all OCPI modules")
 
-val `msgs` = project
+val msgs = project
   .enablePlugins(OssLibPlugin)
   .dependsOn(`prelude`)
   .settings(
@@ -117,8 +132,8 @@ val `endpoints-common` = project
     commonSettings,
     name := "ocpi-endpoints-common",
     description := "OCPI endpoints common",
-    libraryDependencies := logging ++ akka ++ cats ++ specs2 ++
-      akkaHttpTestKit ++ akkaStreamTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := logging ++ akka ++ cats ++ `cats-effect` ++ specs2 ++
+      `akka-http-test-kit` ++ `akka-stream-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-msp-locations` = project
@@ -128,7 +143,7 @@ val `endpoints-msp-locations` = project
     commonSettings,
     name := "ocpi-endpoints-msp-locations",
     description := "OCPI endpoints MSP Locations",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-msp-tokens` = project
@@ -138,7 +153,7 @@ val `endpoints-msp-tokens` = project
     commonSettings,
     name := "ocpi-endpoints-msp-tokens",
     description := "OCPI endpoints MSP Tokens",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-msp-cdrs` = project
@@ -148,7 +163,7 @@ val `endpoints-msp-cdrs` = project
     commonSettings,
     name := "ocpi-endpoints-msp-cdrs",
     description := "OCPI endpoints MSP Cdrs",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-msp-commands` = project
@@ -158,7 +173,7 @@ val `endpoints-msp-commands` = project
     commonSettings,
     name := "ocpi-endpoints-msp-commands",
     description := "OCPI endpoints MSP Commands",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-msp-sessions` = project
@@ -168,7 +183,7 @@ val `endpoints-msp-sessions` = project
     commonSettings,
     name := "ocpi-endpoints-msp-sessions",
     description := "OCPI endpoints MSP Sessions",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-cpo-locations` = project
@@ -178,7 +193,7 @@ val `endpoints-cpo-locations` = project
     commonSettings,
     name := "ocpi-endpoints-cpo-locations",
     description := "OCPI endpoints CPO Locations",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-cpo-tokens` = project
@@ -188,7 +203,7 @@ val `endpoints-cpo-tokens` = project
     commonSettings,
     name := "ocpi-endpoints-cpo-tokens",
     description := "OCPI endpoints CPO Tokens",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-versions` = project
@@ -198,7 +213,7 @@ val `endpoints-versions` = project
     commonSettings,
     name := "ocpi-endpoints-versions",
     description := "OCPI endpoints versions",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ jsonLenses.map(_ % "test") ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `json-lenses`.map(_ % "test") ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `endpoints-registration` = project
@@ -208,17 +223,17 @@ val `endpoints-registration` = project
     commonSettings,
     name := "ocpi-endpoints-registration",
     description := "OCPI endpoints registration",
-    libraryDependencies := specs2 ++ akkaStreamTestKit ++ akkaHttpTestKit ++ jsonLenses.map(_ % "test") ++ akkaHttpSprayJson.map(_ % "test")
+    libraryDependencies := specs2 ++ `akka-stream-test-kit` ++ `akka-http-test-kit` ++ `json-lenses`.map(_ % "test") ++ `akka-http-spray-json`.map(_ % "test")
   )
 
 val `example` = project
   .enablePlugins(AppPlugin)
-  .dependsOn(`endpoints-registration`, `endpoints-versions`, `msgs-spray-json`)
+  .dependsOn(`endpoints-registration`, `endpoints-msp-tokens`, `endpoints-versions`, `msgs-spray-json`, `msgs-circe`)
   .settings(
     commonSettings,
     publish := { },
     description := "OCPI endpoints example app",
-    libraryDependencies := akkaHttpSprayJson
+    libraryDependencies := `akka-http-spray-json` ++ `akka-http-circe`
   )
 
 val `ocpi-endpoints-root` = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,11 @@ val `spray-json` = Seq("io.spray" %% "spray-json"             %   "1.3.5")
 val shapeless = Seq("com.chuusai" %% "shapeless" % "2.3.3")
 
 val circe = {
-  val version = "0.12.3"
+  val version = "0.13.0"
   
   Seq(
     "io.circe" %% "circe-core" % version,
-    "io.circe" %% "circe-generic-extras" % "0.12.2",
+    "io.circe" %% "circe-generic-extras" % version,
     "io.circe" %% "circe-parser" % version
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ val commonSettings = Seq(
   organization := "com.thenewmotion.ocpi",
   licenses += ("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
   crossScalaVersions := List(tnm.ScalaVersion.prev, tnm.ScalaVersion.curr),
-  scalaVersion := tnm.ScalaVersion.prev,
+  scalaVersion := tnm.ScalaVersion.curr,
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",   // source files are in UTF-8
     "-deprecation",         // warn about use of deprecated APIs

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ val circe = {
 }
 
 val `akka-http-circe` = {
-  Seq("de.heikoseeberger" %% "akka-http-circe" % "1.29.1")
+  Seq("de.heikoseeberger" %% "akka-http-circe" % "1.35.3")
 }
 
 def akkaModule(name: String) = {
-  val v = if (name.startsWith("http")) "10.1.12" else "2.5.31"
+  val v = if (name.startsWith("http")) "10.2.0" else "2.6.8"
   "com.typesafe.akka" %% s"akka-$name" % v
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys.libraryDependencies
 
 val logging = Seq(
   "ch.qos.logback"               % "logback-classic"          %   "1.2.3",
-  "org.slf4j"                    % "slf4j-api"                %   "1.7.26")
+  "org.slf4j"                    % "slf4j-api"                %   "1.7.25")
 
 val `spray-json` = Seq("io.spray" %% "spray-json"             %   "1.3.5")
 
@@ -19,7 +19,7 @@ val circe = {
 }
 
 val `akka-http-circe` = {
-  Seq("de.heikoseeberger" %% "akka-http-circe" % "1.35.3")
+  Seq("de.heikoseeberger" %% "akka-http-circe" % "1.34.0")
 }
 
 def akkaModule(name: String) = {

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/EitherUnmarshalling.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/EitherUnmarshalling.scala
@@ -15,12 +15,12 @@ trait EitherUnmarshalling {
     implicit ua: FromEntityUnmarshaller[L], rightTag: ClassTag[R],
              ub: FromEntityUnmarshaller[R], leftTag: ClassTag[L]): FromEntityUnmarshaller[Either[L, R]] =
 
-    Unmarshaller.withMaterializer[HttpEntity, Either[L, R]] { implicit ex ⇒ implicit mat ⇒ value ⇒
+    Unmarshaller.withMaterializer[HttpEntity, Either[L, R]] { implicit ex => implicit mat => value =>
       import akka.http.scaladsl.util.FastFuture._
 
       @inline def right(e: HttpEntity) = ub(e).fast.map(Right(_))
 
-      @inline def fallbackLeft(e: HttpEntity): PartialFunction[Throwable, Future[Either[L, R]]] = { case rightFirstEx ⇒
+      @inline def fallbackLeft(e: HttpEntity): PartialFunction[Throwable, Future[Either[L, R]]] = { case rightFirstEx =>
         val left = ua(e).fast.map(Left(_))
 
         left.transform(

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/HktMarshallable.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/HktMarshallable.scala
@@ -1,0 +1,43 @@
+package com.thenewmotion.ocpi.common
+
+import akka.http.scaladsl.marshalling.{GenericMarshallers, ToRequestMarshaller, ToResponseMarshaller}
+import cats.effect.{ContextShift, IO}
+import scala.concurrent.Future
+
+/**
+  * Turns a higher-kinded type into a Marshaller if
+  * there is a Marshaller for the type argument in implicit scope.
+  *
+  * The bridge between IO and akka-http.
+  */
+trait HktMarshallable[F[_]] {
+  def responseMarshaller[A : ToResponseMarshaller]: ToResponseMarshaller[F[A]]
+  def requestMarshaller[A : ToRequestMarshaller]: ToRequestMarshaller[F[A]]
+}
+
+object HktMarshallableInstances {
+
+  import HktMarshallableSyntax._
+
+  implicit def futureMarshaller: HktMarshallable[Future] = new HktMarshallable[scala.concurrent.Future] {
+    def responseMarshaller[A: ToResponseMarshaller]: ToResponseMarshaller[Future[A]] = implicitly
+    def requestMarshaller[A : ToRequestMarshaller]: ToRequestMarshaller[Future[A]] = implicitly
+  }
+
+  implicit def ioMarshaller(implicit s: ContextShift[IO]): HktMarshallable[IO] = new HktMarshallable[IO] {
+    def responseMarshaller[A](implicit m: ToResponseMarshaller[A]): ToResponseMarshaller[IO[A]] =
+      GenericMarshallers.futureMarshaller(m).compose(io => (s.shift *> io).unsafeToFuture())
+
+    def requestMarshaller[A](implicit m: ToRequestMarshaller[A]): ToRequestMarshaller[IO[A]] =
+      GenericMarshallers.futureMarshaller(m).compose(io => (s.shift *> io).unsafeToFuture())
+  }
+}
+
+
+object HktMarshallableSyntax {
+  implicit def respMarshaller[F[_], A : ToResponseMarshaller](implicit M: HktMarshallable[F]): ToResponseMarshaller[F[A]] =
+    M.responseMarshaller
+
+  implicit def reqMarshaller[F[_], A : ToRequestMarshaller](implicit M: HktMarshallable[F]): ToRequestMarshaller[F[A]] =
+    M.requestMarshaller
+}

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/HktMarshallable.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/HktMarshallable.scala
@@ -17,9 +17,7 @@ trait HktMarshallable[F[_]] {
 
 object HktMarshallableInstances {
 
-  import HktMarshallableSyntax._
-
-  implicit def futureMarshaller: HktMarshallable[Future] = new HktMarshallable[scala.concurrent.Future] {
+  implicit def futureMarshaller: HktMarshallable[Future] = new HktMarshallable[Future] {
     def responseMarshaller[A: ToResponseMarshaller]: ToResponseMarshaller[Future[A]] = implicitly
     def requestMarshaller[A : ToRequestMarshaller]: ToRequestMarshaller[Future[A]] = implicitly
   }

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiResponseUnmarshalling.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/OcpiResponseUnmarshalling.scala
@@ -5,7 +5,6 @@ import _root_.akka.http.scaladsl.model.headers.{Link, LinkParams}
 import _root_.akka.http.scaladsl.model.{HttpResponse, Uri}
 import _root_.akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, FromResponseUnmarshaller, Unmarshaller}
 import msgs.{ErrorResp, SuccessResp}
-import cats.syntax.either._  // For Scala 2.11
 
 case class UnexpectedResponseException(response: HttpResponse)
   extends Exception(s"Unexpected HTTP status code ${response.status}")

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedRoute.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/PaginatedRoute.scala
@@ -23,9 +23,9 @@ trait PaginatedRoute extends Directives with DateDeserializers {
   def DefaultLimit: Int
   def MaxLimit: Int
 
-  private val offset = parameter('offset.as[Int] ? DefaultOffset)
+  private val offset = parameter(Symbol("offset").as[Int] ? DefaultOffset)
 
-  private val limit = parameter('limit.as[Int] ? DefaultLimit).tmap {
+  private val limit = parameter(Symbol("limit").as[Int] ? DefaultLimit).tmap {
     case Tuple1(l) => Math.min(l, MaxLimit)
   }
 

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
@@ -8,7 +8,7 @@ import com.thenewmotion.ocpi.msgs.Ownership.Theirs
 import com.thenewmotion.ocpi.msgs.{AuthToken, GlobalPartyId}
 import scala.concurrent.{ExecutionContext, Future}
 
-class TokenAuthenticator[F[+_]: Effect](
+class TokenAuthenticator[F[_]: Effect](
   toApiUser: AuthToken[Theirs] => F[Option[GlobalPartyId]]
 )(
   implicit executionContext: ExecutionContext

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/common/TokenAuthenticator.scala
@@ -5,24 +5,30 @@ import _root_.akka.http.scaladsl.model.headers.GenericHttpCredentials
 import _root_.akka.http.scaladsl.model.headers.HttpChallenge
 import _root_.akka.http.scaladsl.model.headers.HttpCredentials
 import _root_.akka.http.scaladsl.server.directives.SecurityDirectives.AuthenticationResult
+import cats.effect.IO
 import msgs.Ownership.Theirs
 import msgs.{AuthToken, GlobalPartyId}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class TokenAuthenticator(toApiUser: AuthToken[Theirs] => Future[Option[GlobalPartyId]])(implicit executionContext: ExecutionContext)
-  extends (Option[HttpCredentials] ⇒ Future[AuthenticationResult[GlobalPartyId]]) {
+class TokenAuthenticator(
+  toApiUser: AuthToken[Theirs] => IO[Option[GlobalPartyId]]
+)(
+  implicit executionContext: ExecutionContext
+) extends (Option[HttpCredentials] => Future[AuthenticationResult[GlobalPartyId]]) {
 
-  lazy val challenge = HttpChallenge(scheme = "Token", realm = "ocpi")
+  lazy val challenge: HttpChallenge = HttpChallenge(scheme = "Token", realm = "ocpi")
 
   override def apply(credentials: Option[HttpCredentials]): Future[AuthenticationResult[GlobalPartyId]] = {
     credentials
       .flatMap {
-        case GenericHttpCredentials("Token", token, params) => if(token.nonEmpty) Some(token) else params.headOption.map(_._2)
-        case _ => None
+        case GenericHttpCredentials("Token", token, params) =>
+          if(token.nonEmpty) Some(token) else params.headOption.map(_._2)
+        case _ =>
+          None
       } match {
         case None => Future.successful(Left(challenge))
-        case Some(x) => toApiUser(AuthToken[Theirs](x)).map {
+        case Some(x) => toApiUser(AuthToken[Theirs](x)).unsafeToFuture().map {
           case Some(x2) => Right(x2)
           case None => Left(challenge)
         }

--- a/endpoints-common/src/main/scala/com/thenewmotion/ocpi/package.scala
+++ b/endpoints-common/src/main/scala/com/thenewmotion/ocpi/package.scala
@@ -1,19 +1,17 @@
 package com.thenewmotion
 
 import akka.http.scaladsl.server.Route
-import ocpi.msgs.GlobalPartyId
-import ocpi.msgs.Versions.VersionNumber
-import org.slf4j.LoggerFactory
-import cats.syntax.either._  // Keep Scala 2.11 happy
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import cats.Functor
+import com.thenewmotion.ocpi.msgs.GlobalPartyId
+import com.thenewmotion.ocpi.msgs.Versions.VersionNumber
+import org.slf4j.{Logger, LoggerFactory}
 
 package object ocpi {
-  def Logger(cls: Class[_]) = LoggerFactory.getLogger(cls)
+  def Logger(cls: Class[_]): Logger = LoggerFactory.getLogger(cls)
 
-  implicit class PimpedFutureEither[L, R](value: Future[Either[L, R]]) {
-    def mapRight[T](f: R => T)(implicit executionContext: ExecutionContext) =
+  implicit class RichFEither[F[_]: Functor, L, R](value: F[Either[L, R]]) {
+    import cats.syntax.functor._
+    def mapRight[T](f: R => T): F[Either[L, T]] =
       value.map(_.map(f))
   }
 

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/HktMarshallableFromECInstances.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/HktMarshallableFromECInstances.scala
@@ -1,0 +1,30 @@
+package com.thenewmotion.ocpi.common
+
+import akka.http.scaladsl.marshalling.{GenericMarshallers, ToRequestMarshaller, ToResponseMarshaller}
+import cats.Id
+import cats.effect.{ContextShift, IO}
+import scala.concurrent.ExecutionContext
+
+/**
+  * Convenience marshallers to help keep test code clean
+  */
+object HktMarshallableFromECInstances {
+
+  implicit def ioCsFromEcMarshaller(implicit ec: ExecutionContext): HktMarshallable[IO] = new HktMarshallable[IO] {
+    def responseMarshaller[A](implicit m: ToResponseMarshaller[A]): ToResponseMarshaller[IO[A]] = {
+      implicit val s: ContextShift[IO] = IO.contextShift(ec)
+      GenericMarshallers.futureMarshaller(m).compose(io => (s.shift *> io).unsafeToFuture())
+    }
+
+    def requestMarshaller[A](implicit m: ToRequestMarshaller[A]): ToRequestMarshaller[IO[A]] = {
+      implicit val s: ContextShift[IO] = IO.contextShift(ec)
+      GenericMarshallers.futureMarshaller(m).compose(io => (s.shift *> io).unsafeToFuture())
+    }
+  }
+
+  implicit def idMarshaller: HktMarshallable[Id] = new HktMarshallable[Id] {
+    def responseMarshaller[A: ToResponseMarshaller]: ToResponseMarshaller[A] = implicitly
+    def requestMarshaller[A : ToRequestMarshaller]: ToRequestMarshaller[A] = implicitly
+  }
+}
+

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/IOMatchersExt.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/IOMatchersExt.scala
@@ -1,0 +1,19 @@
+package com.thenewmotion.ocpi.common
+
+import org.specs2.matcher.{Expectable, IOMatchers, MatchFailure, MatchResult, Matcher, ValueChecksBase}
+
+trait IOMatchersExt extends IOMatchers with ValueChecksBase {
+
+  def returnValueLike[T](pattern: PartialFunction[T, MatchResult[_]]): IOMatcher[T] = {
+    val m: Matcher[T] = new Matcher[T] {
+      override def apply[S <: T](a: Expectable[S]) = {
+        val r = if (pattern.isDefinedAt(a.value)) pattern.apply(a.value) else MatchFailure("", "", a)
+        result(r.isSuccess,
+          a.description + " is correct: " + r.message,
+          a.description + " is incorrect: " + r.message,
+          a)
+      }
+    }
+    attemptRun(m, None)
+  }
+}

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/OcpiClientSpec.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/OcpiClientSpec.scala
@@ -113,7 +113,7 @@ class OcpiClientSpec(implicit ee: ExecutionEnv) extends Specification with IOMat
 }
 
 class TestOcpiClient(reqWithAuthFunc: String => IO[HttpResponse])
-  (implicit http: HttpExt) extends OcpiClient {
+  (implicit http: HttpExt) extends OcpiClient[IO] {
 
   override def requestWithAuth(http: HttpExt, req: HttpRequest, token: AuthToken[Ours])
     (implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] =

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/OcpiClientSpec.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/OcpiClientSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse}
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.util.Timeout
 import cats.effect.IO
 import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericClientFailure
@@ -16,8 +16,8 @@ import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp, SuccessResp}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 
 class OcpiClientSpec(implicit ee: ExecutionEnv) extends Specification with IOMatchersExt {
 
@@ -58,8 +58,6 @@ class OcpiClientSpec(implicit ee: ExecutionEnv) extends Specification with IOMat
   trait TestScope extends Scope {
 
     implicit val system = ActorSystem()
-
-    implicit val materializer = ActorMaterializer()
 
     implicit val http = Http()
 

--- a/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedSourceSpec.scala
+++ b/endpoints-common/src/test/scala/com/thenewmotion/ocpi/common/PaginatedSourceSpec.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{GenericHttpCredentials, Link, LinkParams, RawHeader}
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestProbe
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
@@ -102,7 +101,6 @@ class PaginatedSourceSpec(implicit ee: ExecutionEnv) extends Specification with 
 
   trait TestScope extends Scope {
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val dataUrl = "http://localhost:8095/cpo/versions/2.0/somemodule"
 

--- a/endpoints-cpo-locations/src/main/scala/com/thenewmotion/ocpi/locations/CpoLocationsService.scala
+++ b/endpoints-cpo-locations/src/main/scala/com/thenewmotion/ocpi/locations/CpoLocationsService.scala
@@ -7,18 +7,17 @@ import common.Pager
 import common.PaginatedResult
 import msgs.v2_1.Locations._
 
-import scala.concurrent.Future
 
-trait CpoLocationsService {
+trait CpoLocationsService[F[_]] {
   def locations(
     pager: Pager,
     dateFrom: Option[ZonedDateTime] = None,
     dateTo: Option[ZonedDateTime] = None
-  ): Future[Either[LocationsError, PaginatedResult[Location]]]
+  ): F[Either[LocationsError, PaginatedResult[Location]]]
 
-  def location(locId: LocationId): Future[Either[LocationsError, Location]]
+  def location(locId: LocationId): F[Either[LocationsError, Location]]
 
-  def evse(locId: LocationId, evseUid: EvseUid): Future[Either[LocationsError, Evse]]
+  def evse(locId: LocationId, evseUid: EvseUid): F[Either[LocationsError, Evse]]
 
-  def connector(locId: LocationId, evseUid: EvseUid, connectorId: ConnectorId): Future[Either[LocationsError, Connector]]
+  def connector(locId: LocationId, evseUid: EvseUid, connectorId: ConnectorId): F[Either[LocationsError, Connector]]
 }

--- a/endpoints-cpo-locations/src/main/scala/com/thenewmotion/ocpi/locations/MspLocationsClient.scala
+++ b/endpoints-cpo-locations/src/main/scala/com/thenewmotion/ocpi/locations/MspLocationsClient.scala
@@ -1,10 +1,11 @@
 package com.thenewmotion.ocpi.locations
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext}
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
 import akka.stream.Materializer
+import cats.effect.{ContextShift, IO}
 import com.thenewmotion.ocpi.common.{ClientObjectUri, ErrRespUnMar, OcpiClient, SuccessRespUnMar}
 import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
@@ -31,9 +32,10 @@ class MspLocationsClient(
     authToken: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer,
     successU: SuccessRespUnMar[T]
-  ): Future[ErrorRespOr[T]] =
+  ): IO[ErrorRespOr[T]] =
     singleRequest[T](Get(uri.value), authToken).map {
       _.bimap(err => {
         logger.error(s"Could not retrieve data from ${uri.value}. Reason: $err")
@@ -47,8 +49,9 @@ class MspLocationsClient(
     data: T
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     singleRequest[Unit](Put(uri.value, data), authToken).map {
       _.bimap(err => {
         logger.error(s"Could not upload data to ${uri.value}. Reason: $err")
@@ -62,8 +65,9 @@ class MspLocationsClient(
     patch: T
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     singleRequest[Unit](Patch(uri.value, patch), authToken).map {
       _.bimap(err => {
         logger.error(s"Could not update data at ${uri.value}. Reason: $err")
@@ -76,8 +80,9 @@ class MspLocationsClient(
     authToken: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Location]] =
+  ): IO[ErrorRespOr[Location]] =
     get(uri, authToken)
 
   def getEvse(
@@ -85,8 +90,9 @@ class MspLocationsClient(
     authToken: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Evse]] =
+  ): IO[ErrorRespOr[Evse]] =
     get(uri, authToken)
 
   def getConnector(
@@ -94,8 +100,9 @@ class MspLocationsClient(
     authToken: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Connector]] =
+  ): IO[ErrorRespOr[Connector]] =
     get(uri, authToken)
 
   def uploadLocation(
@@ -104,8 +111,9 @@ class MspLocationsClient(
     location: Location
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     upload(uri, authToken, location)
 
   def uploadEvse(
@@ -114,8 +122,9 @@ class MspLocationsClient(
     evse: Evse
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     upload(uri, authToken, evse)
 
   def uploadConnector(
@@ -124,8 +133,9 @@ class MspLocationsClient(
     connector: Connector
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     upload(uri, authToken, connector)
 
   def updateLocation(
@@ -134,8 +144,9 @@ class MspLocationsClient(
     location: LocationPatch
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     update(uri, authToken, location)
 
   def updateEvse(
@@ -144,8 +155,9 @@ class MspLocationsClient(
     evse: EvsePatch
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     update(uri, authToken, evse)
 
   def updateConnector(
@@ -154,7 +166,8 @@ class MspLocationsClient(
     connector: ConnectorPatch
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Unit]] =
+  ): IO[ErrorRespOr[Unit]] =
     update(uri, authToken, connector)
 }

--- a/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensClient.scala
+++ b/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensClient.scala
@@ -5,13 +5,13 @@ import _root_.akka.http.scaladsl._
 import _root_.akka.http.scaladsl.marshalling.ToEntityMarshaller
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
+import cats.effect.{ContextShift, IO}
 import client.RequestBuilding._
 import com.thenewmotion.ocpi.msgs.AuthToken
 import msgs.v2_1.Tokens.{AuthorizationInfo, LocationReferences, TokenUid}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, SuccessRespUnMar}
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import cats.syntax.either._
-
 import scala.concurrent._
 
 class MspTokensClient(
@@ -28,8 +28,9 @@ class MspTokensClient(
     locationReferences: Option[LocationReferences]
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[AuthorizationInfo]] = {
+  ): IO[ErrorRespOr[AuthorizationInfo]] = {
     val oldPath = endpointUri.path
     val authorizeUri = endpointUri.withPath {
       (if (oldPath.endsWithSlash) oldPath + tokenUid.value else  oldPath / tokenUid.value) / "authorize"

--- a/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
+++ b/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
@@ -1,16 +1,16 @@
 package com.thenewmotion.ocpi
 package tokens
 
+import java.time.ZonedDateTime
 import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
+import cats.effect.{ContextShift, IO}
+import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar}
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
-import common.{ErrRespUnMar, OcpiClient, PagedRespUnMar}
-import java.time.ZonedDateTime
-import msgs.{AuthToken, ErrorResp}
-import msgs.v2_1.Tokens.Token
+import com.thenewmotion.ocpi.msgs.v2_1.Tokens.Token
+import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 class TokensClient(
   implicit http: HttpExt,
@@ -24,6 +24,10 @@ class TokensClient(
     dateFrom: Option[ZonedDateTime] = None,
     dateTo: Option[ZonedDateTime] = None,
     pageLimit: Int = OcpiClient.DefaultPageLimit
-  )(implicit ec: ExecutionContext, mat: Materializer): Future[Either[ErrorResp, Iterable[Token]]] =
+  )(
+    implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
+    mat: Materializer
+  ): IO[Either[ErrorResp, Iterable[Token]]] =
     traversePaginatedResource[Token](uri, auth, dateFrom, dateTo, pageLimit)
 }

--- a/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
+++ b/endpoints-cpo-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/TokensClient.scala
@@ -5,18 +5,18 @@ import java.time.ZonedDateTime
 import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
-import cats.effect.{ContextShift, IO}
+import cats.effect.{Async, ContextShift}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar}
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Tokens.Token
 import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
 import scala.concurrent.ExecutionContext
 
-class TokensClient(
+class TokensClient[F[_]: Async](
   implicit http: HttpExt,
   errorU: ErrRespUnMar,
   sucU: PagedRespUnMar[Token]
-) extends OcpiClient {
+) extends OcpiClient[F] {
 
   def getTokens(
     uri: Uri,
@@ -26,8 +26,8 @@ class TokensClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[Either[ErrorResp, Iterable[Token]]] =
+  ): F[Either[ErrorResp, Iterable[Token]]] =
     traversePaginatedResource[Token](uri, auth, dateFrom, dateTo, pageLimit)
 }

--- a/endpoints-cpo-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/MspTokensClientSpec.scala
+++ b/endpoints-cpo-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/MspTokensClientSpec.scala
@@ -101,7 +101,7 @@ class MspTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with 
 
 // generalize to testhttpclient?
 class TestMspTokensClient(reqWithAuthFunc: String => IO[HttpResponse])
-  (implicit httpExt: HttpExt) extends MspTokensClient {
+  (implicit httpExt: HttpExt) extends MspTokensClient[IO] {
 
   override def requestWithAuth(http: HttpExt, req: HttpRequest, token: AuthToken[Ours])
     (implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] =

--- a/endpoints-cpo-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/MspTokensClientSpec.scala
+++ b/endpoints-cpo-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/MspTokensClientSpec.scala
@@ -2,25 +2,25 @@ package com.thenewmotion.ocpi.tokens
 
 import java.net.UnknownHostException
 import akka.actor.ActorSystem
-import akka.http.scaladsl.{Http, HttpExt}
-import akka.http.scaladsl.model.StatusCodes.{ClientError => _, _}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.StatusCodes.{ClientError => _, _}
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.http.scaladsl.{Http, HttpExt}
+import akka.stream.Materializer
 import akka.util.Timeout
+import cats.effect.IO
+import com.thenewmotion.ocpi.common.IOMatchersExt
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
+import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
 import com.thenewmotion.ocpi.msgs.v2_1.Locations.{EvseUid, LocationId}
-import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
 import com.thenewmotion.ocpi.msgs.v2_1.Tokens.{Allowed, AuthorizationInfo, LocationReferences, TokenUid}
+import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import cats.effect.IO
-import com.thenewmotion.ocpi.common.IOMatchersExt
-import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
+import scala.concurrent.{ExecutionContext, Future}
 
 class MspTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with IOMatchersExt {
   "MSpTokensClient" should {
@@ -59,8 +59,6 @@ class MspTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with 
   trait TestScope extends Scope {
 
     implicit val system: ActorSystem = ActorSystem()
-
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
 
     implicit val http: HttpExt = Http()
 

--- a/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
+++ b/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
@@ -2,18 +2,17 @@ package com.thenewmotion.ocpi
 package cdrs
 
 import java.time.ZonedDateTime
-
 import _root_.akka.NotUsed
 import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
-import common.{ErrRespUnMar, OcpiClient, PaginatedSource, PagedRespUnMar}
 import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl.Source
-
-import scala.concurrent.{ExecutionContext, Future}
+import cats.effect.{ContextShift, IO}
+import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
+import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Cdrs.Cdr
-import msgs.AuthToken
+import scala.concurrent.ExecutionContext
 
 class CdrsClient(
   implicit http: HttpExt,
@@ -29,8 +28,9 @@ class CdrsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Iterable[Cdr]]] =
+  ): IO[ErrorRespOr[Iterable[Cdr]]] =
     traversePaginatedResource[Cdr](uri, auth, dateFrom, dateTo, pageLimit)
 
   def cdrsSource(

--- a/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
+++ b/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/CdrsClient.scala
@@ -7,18 +7,18 @@ import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl.Source
-import cats.effect.{ContextShift, IO}
+import cats.effect.{Async, ContextShift}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
 import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Cdrs.Cdr
 import scala.concurrent.ExecutionContext
 
-class CdrsClient(
+class CdrsClient[F[_]: Async](
   implicit http: HttpExt,
   successU: PagedRespUnMar[Cdr],
   errorU: ErrRespUnMar
-) extends OcpiClient {
+) extends OcpiClient[F] {
 
   def getCdrs(
     uri: Uri,
@@ -28,9 +28,9 @@ class CdrsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[ErrorRespOr[Iterable[Cdr]]] =
+  ): F[ErrorRespOr[Iterable[Cdr]]] =
     traversePaginatedResource[Cdr](uri, auth, dateFrom, dateTo, pageLimit)
 
   def cdrsSource(

--- a/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/MspCdrsService.scala
+++ b/endpoints-msp-cdrs/src/main/scala/com/thenewmotion/ocpi/cdrs/MspCdrsService.scala
@@ -3,12 +3,12 @@ package cdrs
 
 import com.thenewmotion.ocpi.msgs.v2_1.Cdrs.{Cdr, CdrId}
 import msgs.GlobalPartyId
-import scala.concurrent.Future
+
 
 /**
   * All methods are to be implemented in an idempotent fashion.
   */
-trait MspCdrsService {
+trait MspCdrsService[F[_]] {
 
   /**
     * @return Either#Right if the cdr has been created
@@ -16,7 +16,7 @@ trait MspCdrsService {
   def createCdr(
     globalPartyId: GlobalPartyId,
     cdr: Cdr
-  ): Future[Either[CdrsError, Unit]]
+  ): F[Either[CdrsError, Unit]]
 
   /**
     * @return existing Cdr or Error if Cdr couldn't be found
@@ -24,5 +24,5 @@ trait MspCdrsService {
   def cdr(
     globalPartyId: GlobalPartyId,
     cdrId: CdrId
-  ): Future[Either[CdrsError, Cdr]]
+  ): F[Either[CdrsError, Cdr]]
 }

--- a/endpoints-msp-commands/src/main/scala/com/thenewmotion/ocpi/commands/CommandClient.scala
+++ b/endpoints-msp-commands/src/main/scala/com/thenewmotion/ocpi/commands/CommandClient.scala
@@ -7,12 +7,13 @@ import _root_.akka.http.scaladsl.marshalling.ToEntityMarshaller
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import cats.effect.{ContextShift, IO}
 import cats.syntax.either._
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient}
-import com.thenewmotion.ocpi.msgs.{AuthToken, SuccessResp}
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Commands.{Command, CommandResponse, CommandResponseType}
-import scala.concurrent.{ExecutionContext, Future}
+import com.thenewmotion.ocpi.msgs.{AuthToken, SuccessResp}
+import scala.concurrent.ExecutionContext
 
 class CommandClient(
   implicit http: HttpExt,
@@ -26,8 +27,9 @@ class CommandClient(
     command: C
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[CommandResponseType]] = {
+  ): IO[ErrorRespOr[CommandResponseType]] = {
 
     val commandUri = commandsUri.copy(path = commandsUri.path ?/ command.name.name)
 

--- a/endpoints-msp-commands/src/main/scala/com/thenewmotion/ocpi/commands/CommandResponseRoute.scala
+++ b/endpoints-msp-commands/src/main/scala/com/thenewmotion/ocpi/commands/CommandResponseRoute.scala
@@ -4,14 +4,14 @@ package commands
 import java.util.UUID
 import _root_.akka.http.scaladsl.server.Route
 import _root_.akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-import msgs.v2_1.Commands.{CommandResponse, CommandResponseType}
-import common._
-import msgs._
-import scala.concurrent.Future
+import cats.Functor
+import com.thenewmotion.ocpi.common._
+import com.thenewmotion.ocpi.msgs._
+import com.thenewmotion.ocpi.msgs.v2_1.Commands.{CommandResponse, CommandResponseType}
 
 object CommandResponseRoute {
-  def apply(
-    callback: (GlobalPartyId, UUID, CommandResponseType) => Future[Option[SuccessResp[Unit]]]
+  def apply[F[_]: Functor: HktMarshallable](
+    callback: (GlobalPartyId, UUID, CommandResponseType) => F[Option[SuccessResp[Unit]]]
   )(
     implicit errorM: ErrRespMar,
     succM: SuccessRespMar[Unit],
@@ -19,8 +19,8 @@ object CommandResponseRoute {
   ) = new CommandResponseRoute(callback)
 }
 
-class CommandResponseRoute private[ocpi](
-  callback: (GlobalPartyId, UUID, CommandResponseType) => Future[Option[SuccessResp[Unit]]]
+class CommandResponseRoute[F[_]: Functor: HktMarshallable] private[ocpi](
+  callback: (GlobalPartyId, UUID, CommandResponseType) => F[Option[SuccessResp[Unit]]]
 )(
   implicit errorM: ErrRespMar,
   succM: SuccessRespMar[Unit],
@@ -32,6 +32,8 @@ class CommandResponseRoute private[ocpi](
     apiUser: GlobalPartyId
   ): Route =
     handleRejections(OcpiRejectionHandler.Default)(routeWithoutRh(apiUser))
+
+  import HktMarshallableSyntax._
 
   private[commands] def routeWithoutRh(
     apiUser: GlobalPartyId

--- a/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandClientSpec.scala
+++ b/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandClientSpec.scala
@@ -130,7 +130,7 @@ object GenericRespTypes {
 
 
 class TestMspCommandsClient(reqWithAuthFunc: String => IO[HttpResponse])
-  (implicit httpExt: HttpExt) extends CommandClient {
+  (implicit httpExt: HttpExt) extends CommandClient[IO] {
 
   override def requestWithAuth(http: HttpExt, req: HttpRequest, token: AuthToken[Ours])
     (implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] =

--- a/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandClientSpec.scala
+++ b/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandClientSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.util.Timeout
 import cats.effect.IO
 import com.thenewmotion.ocpi.common.IOMatchersExt
@@ -72,8 +72,6 @@ class CommandClientSpec(implicit ec: ExecutionContext) extends Specification wit
   trait TestScope extends Scope {
 
     implicit val system = ActorSystem()
-
-    implicit val materializer = ActorMaterializer()
 
     implicit val http = Http()
 

--- a/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandResponseRouteSpec.scala
+++ b/endpoints-msp-commands/src/test/scala/com/thenewmotion/ocpi/commands/CommandResponseRouteSpec.scala
@@ -1,15 +1,13 @@
 package com.thenewmotion.ocpi.commands
 
+import java.util.UUID
 import akka.http.scaladsl.testkit.Specs2RouteTest
+import cats.effect.IO
+import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericSuccess
+import com.thenewmotion.ocpi.msgs.v2_1.Commands.{CommandResponse, CommandResponseType}
 import com.thenewmotion.ocpi.msgs.{GlobalPartyId, SuccessResp}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import java.util.UUID
-
-import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericSuccess
-import com.thenewmotion.ocpi.msgs.v2_1.Commands.{CommandResponse, CommandResponseType}
-
-import scala.concurrent.Future
 
 class CommandResponseRouteSpec extends Specification with Specs2RouteTest {
 
@@ -34,8 +32,9 @@ class CommandResponseRouteSpec extends Specification with Specs2RouteTest {
 
     val apiUser = GlobalPartyId("NL", "TNM")
 
-    val route = new CommandResponseRoute( (gpi, uuid, crt) =>
-        Future.successful(Some(SuccessResp(GenericSuccess)))
+    import com.thenewmotion.ocpi.common.HktMarshallableFromECInstances._
+    val route = new CommandResponseRoute[IO]( (gpi, uuid, crt) =>
+        IO.pure(Some(SuccessResp(GenericSuccess)))
     )
   }
 }

--- a/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
+++ b/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
@@ -2,18 +2,17 @@ package com.thenewmotion.ocpi
 package locations
 
 import java.time.ZonedDateTime
-
 import _root_.akka.NotUsed
 import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
-import common.{ErrRespUnMar, OcpiClient, PaginatedSource, PagedRespUnMar}
-import msgs.v2_1.Locations.Location
 import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl.Source
-
-import scala.concurrent.{ExecutionContext, Future}
+import cats.effect.{ContextShift, IO}
+import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
+import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
-import msgs.AuthToken
+import com.thenewmotion.ocpi.msgs.v2_1.Locations.Location
+import scala.concurrent.ExecutionContext
 
 class LocationsClient(
   implicit http: HttpExt,
@@ -29,8 +28,9 @@ class LocationsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Iterable[Location]]] =
+  ): IO[ErrorRespOr[Iterable[Location]]] =
     traversePaginatedResource[Location](uri, auth, dateFrom, dateTo, pageLimit)
 
   def locationsSource(

--- a/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
+++ b/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/LocationsClient.scala
@@ -7,18 +7,18 @@ import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl.Source
-import cats.effect.{ContextShift, IO}
+import cats.effect.{Async, ContextShift}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
 import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Locations.Location
 import scala.concurrent.ExecutionContext
 
-class LocationsClient(
+class LocationsClient[F[_]: Async](
   implicit http: HttpExt,
   successU: PagedRespUnMar[Location],
   errorU: ErrRespUnMar
-) extends OcpiClient {
+) extends OcpiClient[F] {
 
   def getLocations(
     uri: Uri,
@@ -28,9 +28,9 @@ class LocationsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[ErrorRespOr[Iterable[Location]]] =
+  ): F[ErrorRespOr[Iterable[Location]]] =
     traversePaginatedResource[Location](uri, auth, dateFrom, dateTo, pageLimit)
 
   def locationsSource(

--- a/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/MspLocationsService.scala
+++ b/endpoints-msp-locations/src/main/scala/com/thenewmotion/ocpi/locations/MspLocationsService.scala
@@ -1,6 +1,7 @@
 package com.thenewmotion.ocpi
 package locations
 
+import cats.Applicative
 import com.thenewmotion.ocpi.common.CreateOrUpdateResult
 import msgs.GlobalPartyId
 import msgs.v2_1.Locations._
@@ -8,22 +9,22 @@ import cats.syntax.either._
 import cats.syntax.option._
 import com.thenewmotion.ocpi.locations.LocationsError.IncorrectLocationId
 
-import scala.concurrent.Future
-
 /**
   * All methods are to be implemented in an idempotent fashion.
   */
-trait MspLocationsService {
+trait MspLocationsService[F[_]] {
 
   protected[locations] def createOrUpdateLocation(
     apiUser: GlobalPartyId,
     locId: LocationId,
     loc: Location
-  ): Future[Either[LocationsError, CreateOrUpdateResult]] = {
+  )(
+    implicit A: Applicative[F]
+  ): F[Either[LocationsError, CreateOrUpdateResult]] = {
     if (loc.id == locId) {
       createOrUpdateLocation(apiUser, loc)
     } else
-      Future.successful(
+      Applicative[F].pure(
         IncorrectLocationId(s"Token id from Url is $locId, but id in JSON body is ${loc.id}".some).asLeft
       )
   }
@@ -31,14 +32,14 @@ trait MspLocationsService {
   def createOrUpdateLocation(
     globalPartyId: GlobalPartyId,
     loc: Location
-  ): Future[Either[LocationsError, CreateOrUpdateResult]]
+  ): F[Either[LocationsError, CreateOrUpdateResult]]
 
   def addOrUpdateEvse(
     globalPartyId: GlobalPartyId,
     locId: LocationId,
     evseUid: EvseUid,
     evse: Evse
-  ): Future[Either[LocationsError, CreateOrUpdateResult]]
+  ): F[Either[LocationsError, CreateOrUpdateResult]]
 
   def addOrUpdateConnector(
     globalPartyId: GlobalPartyId,
@@ -46,20 +47,20 @@ trait MspLocationsService {
     evseUid: EvseUid,
     connId: ConnectorId,
     connector: Connector
-  ): Future[Either[LocationsError, CreateOrUpdateResult]]
+  ): F[Either[LocationsError, CreateOrUpdateResult]]
 
   def updateLocation(
     globalPartyId: GlobalPartyId,
     locId: LocationId,
     locPatch: LocationPatch
-  ): Future[Either[LocationsError, Unit]]
+  ): F[Either[LocationsError, Unit]]
 
   def updateEvse(
     globalPartyId: GlobalPartyId,
     locId: LocationId,
     evseUid: EvseUid,
     evsePatch: EvsePatch
-  ): Future[Either[LocationsError, Unit]]
+  ): F[Either[LocationsError, Unit]]
 
   def updateConnector(
     globalPartyId: GlobalPartyId,
@@ -67,24 +68,24 @@ trait MspLocationsService {
     evseUid: EvseUid,
     connId: ConnectorId,
     connectorPatch: ConnectorPatch
-  ): Future[Either[LocationsError, Unit]]
+  ): F[Either[LocationsError, Unit]]
 
   def location(
     globalPartyId: GlobalPartyId,
     locId: LocationId
-  ): Future[Either[LocationsError, Location]]
+  ): F[Either[LocationsError, Location]]
 
   def evse(
     globalPartyId: GlobalPartyId,
     locId: LocationId,
     evseUid: EvseUid
-  ): Future[Either[LocationsError, Evse]]
+  ): F[Either[LocationsError, Evse]]
 
   def connector(
     globalPartyId: GlobalPartyId,
     locId: LocationId,
     evseUid: EvseUid,
     connectorId: ConnectorId
-  ): Future[Either[LocationsError, Connector]]
+  ): F[Either[LocationsError, Connector]]
 
 }

--- a/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
+++ b/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
@@ -1,18 +1,17 @@
 package com.thenewmotion.ocpi.sessions
 
 import java.time.ZonedDateTime
-
 import akka.NotUsed
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import cats.effect.{ContextShift, IO}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
 import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Sessions.Session
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class SessionsClient(
   implicit http: HttpExt,
@@ -28,8 +27,9 @@ class SessionsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
+    cs: ContextShift[IO],
     mat: Materializer
-  ): Future[ErrorRespOr[Iterable[Session]]] =
+  ): IO[ErrorRespOr[Iterable[Session]]] =
     traversePaginatedResource[Session](uri, auth, Some(dateFrom), dateTo, pageLimit)
 
   def sessionsSource(

--- a/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
+++ b/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsClient.scala
@@ -6,18 +6,18 @@ import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import cats.effect.{ContextShift, IO}
+import cats.effect.{Async, ContextShift}
 import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, PagedRespUnMar, PaginatedSource}
 import com.thenewmotion.ocpi.msgs.AuthToken
 import com.thenewmotion.ocpi.msgs.Ownership.Ours
 import com.thenewmotion.ocpi.msgs.v2_1.Sessions.Session
 import scala.concurrent.ExecutionContext
 
-class SessionsClient(
+class SessionsClient[F[_]: Async](
   implicit http: HttpExt,
   successU: PagedRespUnMar[Session],
   errorU: ErrRespUnMar
-) extends OcpiClient {
+) extends OcpiClient[F] {
 
   def getSessions(
     uri: Uri,
@@ -27,9 +27,9 @@ class SessionsClient(
     pageLimit: Int = OcpiClient.DefaultPageLimit
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[ErrorRespOr[Iterable[Session]]] =
+  ): F[ErrorRespOr[Iterable[Session]]] =
     traversePaginatedResource[Session](uri, auth, Some(dateFrom), dateTo, pageLimit)
 
   def sessionsSource(

--- a/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsService.scala
+++ b/endpoints-msp-sessions/src/main/scala/com/thenewmotion/ocpi/sessions/SessionsService.scala
@@ -1,5 +1,6 @@
 package com.thenewmotion.ocpi.sessions
 
+import cats.Applicative
 import com.thenewmotion.ocpi.common.CreateOrUpdateResult
 import com.thenewmotion.ocpi.msgs.GlobalPartyId
 import com.thenewmotion.ocpi.msgs.v2_1.Sessions.{Session, SessionId, SessionPatch}
@@ -7,22 +8,22 @@ import com.thenewmotion.ocpi.sessions.SessionError.IncorrectSessionId
 import cats.syntax.either._
 import cats.syntax.option._
 
-import scala.concurrent.Future
-
 /**
   * All methods are to be implemented in an idempotent fashion.
   */
-trait SessionsService {
+trait SessionsService[F[_]] {
 
   protected[sessions] def createOrUpdateSession(
     apiUser: GlobalPartyId,
     sessionId: SessionId,
     session: Session
-  ): Future[Either[SessionError, CreateOrUpdateResult]] = {
+  )(
+    implicit A: Applicative[F]
+  ): F[Either[SessionError, CreateOrUpdateResult]] = {
     if (session.id == sessionId) {
       createOrUpdateSession(apiUser, session)
     } else
-      Future.successful(
+      Applicative[F].pure(
         IncorrectSessionId(s"Session id from Url is $sessionId, but id in JSON body is ${session.id}".some).asLeft
       )
   }
@@ -30,17 +31,17 @@ trait SessionsService {
   def createOrUpdateSession(
     globalPartyId: GlobalPartyId,
     session: Session
-  ): Future[Either[SessionError, CreateOrUpdateResult]]
+  ): F[Either[SessionError, CreateOrUpdateResult]]
 
   def updateSession(
     globalPartyId: GlobalPartyId,
     sessionId: SessionId,
     session: SessionPatch
-  ): Future[Either[SessionError, Unit]]
+  ): F[Either[SessionError, Unit]]
 
   def session(
     globalPartyId: GlobalPartyId,
     sessionId: SessionId
-  ): Future[Either[SessionError, Session]]
+  ): F[Either[SessionError, Session]]
 
 }

--- a/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensService.scala
+++ b/endpoints-msp-tokens/src/main/scala/com/thenewmotion/ocpi/tokens/MspTokensService.scala
@@ -4,7 +4,6 @@ import java.time.ZonedDateTime
 import com.thenewmotion.ocpi.common.{Pager, PaginatedResult}
 import com.thenewmotion.ocpi.msgs.GlobalPartyId
 import com.thenewmotion.ocpi.msgs.v2_1.Tokens.{AuthorizationInfo, LocationReferences, Token, TokenUid}
-import scala.concurrent.Future
 
 sealed trait AuthorizeError
 
@@ -16,17 +15,17 @@ object AuthorizeError {
 /**
   * All methods are to be implemented in an idempotent fashion.
   */
-trait MspTokensService {
+trait MspTokensService[F[_]] {
   def tokens(
     globalPartyId: GlobalPartyId,
     pager: Pager,
     dateFrom: Option[ZonedDateTime] = None,
     dateTo: Option[ZonedDateTime] = None
-  ): Future[PaginatedResult[Token]]
+  ): F[PaginatedResult[Token]]
 
   def authorize(
     globalPartyId: GlobalPartyId,
     tokenUid: TokenUid,
     locationReferences: Option[LocationReferences]
-  ): Future[Either[AuthorizeError, AuthorizationInfo]]
+  ): F[Either[AuthorizeError, AuthorizationInfo]]
 }

--- a/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
+++ b/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
@@ -3,47 +3,46 @@ package tokens
 
 import java.net.UnknownHostException
 import java.time.ZonedDateTime
-
 import akka.actor.ActorSystem
-import akka.http.scaladsl.{Http, HttpExt}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.StatusCodes.{ClientError => _, _}
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse}
-import akka.util.Timeout
-import scala.concurrent.duration.FiniteDuration
-
-import org.specs2.matcher.FutureMatchers
+import akka.http.scaladsl.{Http, HttpExt}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.util.{Timeout => AkkaTimeout}
+import cats.effect.IO
+import com.thenewmotion.ocpi.ZonedDateTimeParser._
+import com.thenewmotion.ocpi.common.{ClientObjectUri, IOMatchersExt}
+import com.thenewmotion.ocpi.msgs.Ownership.Ours
+import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
+import com.thenewmotion.ocpi.msgs.v2_1.Tokens._
+import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import akka.http.scaladsl.model.ContentTypes._
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
-import com.thenewmotion.ocpi.common.ClientObjectUri
-import akka.http.scaladsl.model.StatusCodes.{ClientError => _, _}
-import akka.stream.{ActorMaterializer, Materializer}
-import com.thenewmotion.ocpi.msgs.Ownership.Ours
-import com.thenewmotion.ocpi.msgs.{AuthToken, ErrorResp}
-import com.thenewmotion.ocpi.msgs.v2_1.Tokens._
-import org.specs2.concurrent.ExecutionEnv
-import com.thenewmotion.ocpi.ZonedDateTimeParser._
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
 
-class CpoTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with FutureMatchers {
+
+class CpoTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with IOMatchersExt {
 
   "CPO Tokens client" should {
 
     "Retrieve a Token as it is stored in the CPO system" in new TestScope {
 
-      client.getToken(tokenUri, AuthToken[Ours]("auth"), TokenUid("123")) must beLike[Either[ErrorResp, Token]] {
-        case Right(r) =>
-          r.uid === TokenUid("123")
-      }.await
+        client.getToken(tokenUri, AuthToken[Ours]("auth"), TokenUid("123")) must returnValueLike[Either[ErrorResp, Token]] {
+          case Right(r) =>
+            r.uid === TokenUid("123")
+        }
     }
 
     "Push new/updated Token object to the CPO" in new TestScope {
 
-      client.uploadToken(tokenUri, AuthToken[Ours]("auth"), testToken) must beLike[Either[ErrorResp, Unit]] {
+      client.uploadToken(tokenUri, AuthToken[Ours]("auth"), testToken) must returnValueLike[Either[ErrorResp, Unit]] {
         case Right(_) => ok
-      }.await
+      }
     }
 
     "Notify the CPO of partial updates to a Token" in new TestScope {
@@ -52,9 +51,9 @@ class CpoTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with 
         valid = Some(false)
       )
 
-      client.updateToken(tokenUri, AuthToken[Ours]("auth"), patch) must beLike[Either[ErrorResp, Unit]] {
+      client.updateToken(tokenUri, AuthToken[Ours]("auth"), patch) must returnValueLike[Either[ErrorResp, Unit]] {
         case Right(_) => ok
-      }.await
+      }
     }
   }
 
@@ -109,13 +108,13 @@ class CpoTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with 
            |""".stripMargin.getBytes)
     )
 
-    implicit val timeout: Timeout = Timeout(FiniteDuration(20, "seconds"))
+    implicit val timeout: AkkaTimeout = AkkaTimeout(FiniteDuration(20, "seconds"))
 
     val tokenUrl = s"$dataUrl/$ourCountryCode/$ourPartyId/${testToken.uid}"
 
     def requestWithAuth(uri: String) = uri match {
-      case `tokenUrl` => Future.successful(successResp)
-      case x =>         Future.failed(new UnknownHostException(x.toString))
+      case `tokenUrl` => IO.pure(successResp)
+      case x =>          IO.raiseError(new UnknownHostException(x.toString))
     }
 
     lazy val client = new TestCpoTokensClient(requestWithAuth)
@@ -129,11 +128,11 @@ object GenericRespTypes {
 }
 
 
-class TestCpoTokensClient(reqWithAuthFunc: String => Future[HttpResponse])
+class TestCpoTokensClient(reqWithAuthFunc: String => IO[HttpResponse])
   (implicit httpExt: HttpExt) extends CpoTokensClient {
 
   override def requestWithAuth(http: HttpExt, req: HttpRequest, token: AuthToken[Ours])
     (implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] =
-    req.uri.toString match { case x => reqWithAuthFunc(x) }
+    req.uri.toString match { case x => reqWithAuthFunc(x).unsafeToFuture() }
 
 }

--- a/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
+++ b/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
@@ -129,7 +129,7 @@ object GenericRespTypes {
 
 
 class TestCpoTokensClient(reqWithAuthFunc: String => IO[HttpResponse])
-  (implicit httpExt: HttpExt) extends CpoTokensClient {
+  (implicit httpExt: HttpExt) extends CpoTokensClient[IO] {
 
   override def requestWithAuth(http: HttpExt, req: HttpRequest, token: AuthToken[Ours])
     (implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] =

--- a/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
+++ b/endpoints-msp-tokens/src/test/scala/com/thenewmotion/ocpi/tokens/CpoTokensClientSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.StatusCodes.{ClientError => _, _}
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse}
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.util.{Timeout => AkkaTimeout}
 import cats.effect.IO
 import com.thenewmotion.ocpi.ZonedDateTimeParser._
@@ -60,8 +60,6 @@ class CpoTokensClientSpec(implicit ee: ExecutionEnv) extends Specification with 
   trait TestScope extends Scope {
 
     implicit val system = ActorSystem()
-
-    implicit val materializer = ActorMaterializer()
 
     implicit val http = Http()
 

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationClient.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationClient.scala
@@ -1,46 +1,48 @@
 package com.thenewmotion.ocpi
 package registration
 
-import scala.concurrent.ExecutionContext
 import _root_.akka.http.scaladsl.HttpExt
 import _root_.akka.http.scaladsl.client.RequestBuilding._
 import _root_.akka.http.scaladsl.marshalling.ToEntityMarshaller
 import _root_.akka.http.scaladsl.model.Uri
 import _root_.akka.stream.Materializer
-import cats.effect.{ContextShift, IO}
-import common.{ErrRespUnMar, OcpiClient, SuccessRespUnMar}
-import msgs.Ownership.{Ours, Theirs}
-import msgs.Versions._
-import msgs.v2_1.Credentials.Creds
-import msgs.{AuthToken, Url}
-import registration.RegistrationError._
+import cats.effect.{Async, ContextShift}
 import cats.syntax.either._
+import cats.syntax.functor._
+import cats.syntax.applicativeError._
+import com.thenewmotion.ocpi.common.{ErrRespUnMar, OcpiClient, SuccessRespUnMar}
+import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
+import com.thenewmotion.ocpi.msgs.Versions._
+import com.thenewmotion.ocpi.msgs.v2_1.Credentials.Creds
+import com.thenewmotion.ocpi.msgs.{AuthToken, Url}
+import com.thenewmotion.ocpi.registration.RegistrationError._
+import scala.concurrent.ExecutionContext
 
-class RegistrationClient(
+class RegistrationClient[F[_]: Async](
   implicit http: HttpExt,
   errorU: ErrRespUnMar,
   sucListVerU: SuccessRespUnMar[List[Version]],
   sucVerDetU: SuccessRespUnMar[VersionDetails],
   sucCredsU: SuccessRespUnMar[Creds[Theirs]],
   credsM: ToEntityMarshaller[Creds[Ours]]
-) extends OcpiClient {
+) extends OcpiClient[F] {
 
   def getTheirVersions(
     uri: Uri,
     token: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[Either[RegistrationError, List[Version]]] = {
+  ): F[Either[RegistrationError, List[Version]]] = {
     def errorMsg = s"Could not retrieve the versions information from $uri with token $token."
-    val regError = VersionsRetrievalFailed
+    val regError: RegistrationError = VersionsRetrievalFailed
 
     singleRequest[List[Version]](Get(uri), token) map {
       _.bimap(err => {
         logger.error(errorMsg + s" Reason: $err"); regError
       }, _.data)
-    } handleErrorWith { t => logger.error(errorMsg, t); IO.pure(regError.asLeft) }
+    } handleErrorWith { t => logger.error(errorMsg, t); Async[F].pure(regError.asLeft) }
   }
 
   def getTheirVersionDetails(
@@ -48,17 +50,17 @@ class RegistrationClient(
     token: AuthToken[Ours]
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[Either[RegistrationError, VersionDetails]] = {
+  ): F[Either[RegistrationError, VersionDetails]] = {
     def errorMsg = s"Could not retrieve the version details from $uri with token $token."
-    val regError = VersionDetailsRetrievalFailed
+    val regError: RegistrationError = VersionDetailsRetrievalFailed
 
     singleRequest[VersionDetails](Get(uri), token) map {
       _.bimap(err => {
         logger.error(errorMsg + s" Reason: $err"); regError
       }, _.data)
-    } handleErrorWith { t => logger.error(errorMsg, t); IO.pure(regError.asLeft) }
+    } handleErrorWith { t => logger.error(errorMsg, t); Async[F].pure(regError.asLeft) }
   }
 
   def sendCredentials(
@@ -67,12 +69,12 @@ class RegistrationClient(
     credToConnectToUs: Creds[Ours]
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[Either[RegistrationError, Creds[Theirs]]] = {
+  ): F[Either[RegistrationError, Creds[Theirs]]] = {
     def errorMsg = s"Could not retrieve their credentials from $theirCredUrl with token " +
       s"$tokenToConnectToThem when sending our credentials $credToConnectToUs."
-    val regError = SendingCredentialsFailed
+    val regError: RegistrationError = SendingCredentialsFailed
 
     singleRequest[Creds[Theirs]](
       Post(theirCredUrl.value, credToConnectToUs), tokenToConnectToThem
@@ -80,7 +82,7 @@ class RegistrationClient(
       _.bimap(err => {
         logger.error(errorMsg + s" Reason: $err"); regError
       }, _.data)
-    } handleErrorWith { t => logger.error(errorMsg, t); IO.pure(regError.asLeft) }
+    } handleErrorWith { t => logger.error(errorMsg, t); Async[F].pure(regError.asLeft) }
   }
 
   def updateCredentials(
@@ -89,12 +91,12 @@ class RegistrationClient(
     credToConnectToUs: Creds[Ours]
   )(
     implicit ec: ExecutionContext,
-    cs: ContextShift[IO],
+    cs: ContextShift[F],
     mat: Materializer
-  ): IO[Either[RegistrationError, Creds[Theirs]]] = {
+  ): F[Either[RegistrationError, Creds[Theirs]]] = {
     def errorMsg = s"Could not retrieve their credentials from $theirCredUrl with token" +
       s"$tokenToConnectToThem when sending our credentials $credToConnectToUs."
-    val regError = UpdatingCredentialsFailed
+    val regError: RegistrationError = UpdatingCredentialsFailed
 
     singleRequest[Creds[Theirs]](
       Put(theirCredUrl.value, credToConnectToUs), tokenToConnectToThem
@@ -102,6 +104,6 @@ class RegistrationClient(
       _.bimap(err => {
         logger.error(errorMsg + s" Reason: $err"); regError
       }, _.data)
-    } handleErrorWith { t => logger.error(errorMsg, t); IO.pure(regError.asLeft) }
+    } handleErrorWith { t => logger.error(errorMsg, t); Async[F].pure(regError.asLeft) }
   }
 }

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRepo.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRepo.scala
@@ -4,19 +4,17 @@ package registration
 import msgs.Ownership.Theirs
 import msgs.Versions.{Endpoint, VersionNumber}
 import msgs.v2_1.Credentials.Creds
-import msgs.{GlobalPartyId, AuthToken}
+import msgs.{AuthToken, GlobalPartyId}
 
-import scala.concurrent.Future
-
-trait RegistrationRepo {
+trait RegistrationRepo[F[_]] {
 
   def isPartyRegistered(
     globalPartyId: GlobalPartyId
-  ): Future[Boolean]
+  ): F[Boolean]
 
   def findTheirAuthToken(
     globalPartyId: GlobalPartyId
-  ): Future[Option[AuthToken[Theirs]]]
+  ): F[Option[AuthToken[Theirs]]]
 
   // Called after a 3rd party has called our credentials endpoint with a POST or a PUT
   def persistInfoAfterConnectToUs(
@@ -25,7 +23,7 @@ trait RegistrationRepo {
     token: AuthToken[Theirs],
     creds: Creds[Theirs],
     endpoints: Iterable[Endpoint]
-  ): Future[Unit]
+  ): F[Unit]
 
   // Called after _we_ start the registration by calling _their_ credentials endpoint with a POST or a PUT
   def persistInfoAfterConnectToThem(
@@ -33,9 +31,9 @@ trait RegistrationRepo {
     token: AuthToken[Theirs],
     creds: Creds[Theirs],
     endpoints: Iterable[Endpoint]
-  ): Future[Unit]
+  ): F[Unit]
 
   def deletePartyInformation(
     globalPartyId: GlobalPartyId
-  ): Future[Unit]
+  ): F[Unit]
 }

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
@@ -37,9 +37,9 @@ class RegistrationRoute[F[_]: Effect: HktMarshallable] private[ocpi](
   cs: ContextShift[IO]
 ) extends OcpiDirectives {
 
-  import ErrorMarshalling._
-  import HktMarshallableInstances._
   import HktMarshallableSyntax._
+  import HktMarshallableInstances._
+  import ErrorMarshalling._
 
   def apply(
     accessedVersion: VersionNumber,

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
@@ -1,40 +1,45 @@
 package com.thenewmotion.ocpi
 package registration
 
-import msgs.OcpiStatusCode.GenericSuccess
-
-import scala.concurrent.ExecutionContext
-import ErrorMarshalling._
 import _root_.akka.http.scaladsl.server.Route
 import _root_.akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import _root_.akka.stream.Materializer
-import com.thenewmotion.ocpi.common.{ErrRespMar, OcpiDirectives, SuccessRespMar}
+import cats.effect.{ContextShift, Effect, IO}
+import com.thenewmotion.ocpi.common._
+import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericSuccess
+import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
 import com.thenewmotion.ocpi.msgs.Versions.VersionNumber
 import com.thenewmotion.ocpi.msgs.v2_1.Credentials.Creds
-import msgs.Ownership.{Ours, Theirs}
-import msgs.{GlobalPartyId, SuccessResp}
+import com.thenewmotion.ocpi.msgs.{GlobalPartyId, SuccessResp}
+import scala.concurrent.ExecutionContext
 
 object RegistrationRoute {
-  def apply(
+  def apply[F[_]: Effect: HktMarshallable](
     service: RegistrationService
   )(
     implicit mat: Materializer,
     errorM: ErrRespMar,
     succOurCredsM: SuccessRespMar[Creds[Ours]],
     succUnitM: SuccessRespMar[Unit],
-    theirCredsU: FromEntityUnmarshaller[Creds[Theirs]]
-  ): RegistrationRoute = new RegistrationRoute(service)
+    theirCredsU: FromEntityUnmarshaller[Creds[Theirs]],
+    cs: ContextShift[IO]
+  ): RegistrationRoute[F] = new RegistrationRoute(service)
 }
 
-class RegistrationRoute private[ocpi](
+class RegistrationRoute[F[_]: Effect: HktMarshallable] private[ocpi](
   service: RegistrationService
 )(
   implicit mat: Materializer,
   errorM: ErrRespMar,
   succOurCredsM: SuccessRespMar[Creds[Ours]],
   succUnitM: SuccessRespMar[Unit],
-  theirCredsU: FromEntityUnmarshaller[Creds[Theirs]]
+  theirCredsU: FromEntityUnmarshaller[Creds[Theirs]],
+  cs: ContextShift[IO]
 ) extends OcpiDirectives {
+
+  import ErrorMarshalling._
+  import HktMarshallableInstances._
+  import HktMarshallableSyntax._
 
   def apply(
     accessedVersion: VersionNumber,

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationRoute.scala
@@ -4,7 +4,7 @@ package registration
 import _root_.akka.http.scaladsl.server.Route
 import _root_.akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import _root_.akka.stream.Materializer
-import cats.effect.{ContextShift, Effect, IO}
+import cats.effect.Effect
 import com.thenewmotion.ocpi.common._
 import com.thenewmotion.ocpi.msgs.OcpiStatusCode.GenericSuccess
 import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
@@ -15,31 +15,28 @@ import scala.concurrent.ExecutionContext
 
 object RegistrationRoute {
   def apply[F[_]: Effect: HktMarshallable](
-    service: RegistrationService
+    service: RegistrationService[F]
   )(
     implicit mat: Materializer,
     errorM: ErrRespMar,
     succOurCredsM: SuccessRespMar[Creds[Ours]],
     succUnitM: SuccessRespMar[Unit],
-    theirCredsU: FromEntityUnmarshaller[Creds[Theirs]],
-    cs: ContextShift[IO]
+    theirCredsU: FromEntityUnmarshaller[Creds[Theirs]]
   ): RegistrationRoute[F] = new RegistrationRoute(service)
 }
 
 class RegistrationRoute[F[_]: Effect: HktMarshallable] private[ocpi](
-  service: RegistrationService
+  service: RegistrationService[F]
 )(
   implicit mat: Materializer,
   errorM: ErrRespMar,
   succOurCredsM: SuccessRespMar[Creds[Ours]],
   succUnitM: SuccessRespMar[Unit],
-  theirCredsU: FromEntityUnmarshaller[Creds[Theirs]],
-  cs: ContextShift[IO]
+  theirCredsU: FromEntityUnmarshaller[Creds[Theirs]]
 ) extends OcpiDirectives {
 
-  import HktMarshallableSyntax._
-  import HktMarshallableInstances._
   import ErrorMarshalling._
+  import HktMarshallableSyntax._
 
   def apply(
     accessedVersion: VersionNumber,

--- a/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationService.scala
+++ b/endpoints-registration/src/main/scala/com/thenewmotion/ocpi/registration/RegistrationService.scala
@@ -194,7 +194,7 @@ class RegistrationService[F[_]: Async](
     def getCredsEndpoint(verDet: VersionDetails) = Applicative[F].pure(
       verDet.endpoints.find(_.identifier == Credentials) toRight {
         logger.debug("Credentials endpoint not found in retrieved endpoints for version {}", verDet.version)
-        SendingCredentialsFailed: RegistrationError
+        SendingCredentialsFailed
       }
     )
 
@@ -248,7 +248,7 @@ class RegistrationService[F[_]: Async](
 
   def credsToConnectToUs(globalPartyId: GlobalPartyId): F[Either[RegistrationError, Creds[Ours]]] = {
     (for {
-      theirToken <- result(repo.findTheirAuthToken(globalPartyId).map(_ toRight (UnknownParty(globalPartyId): RegistrationError)))
+      theirToken <- result(repo.findTheirAuthToken(globalPartyId).map(_ toRight[RegistrationError] UnknownParty(globalPartyId)))
     } yield generateCreds(theirToken)).value
   }
 

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
@@ -4,6 +4,7 @@ package registration
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
+import cats.effect.IO
 import com.thenewmotion.ocpi.common.IOMatchersExt
 import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
 import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.BusinessDetails
@@ -67,6 +68,7 @@ class RegistrationClientSpec(environment: Env)
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
 
-    val client = new RegistrationClient()
+    val client = new RegistrationClient[IO]()
   }
 }
+

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
@@ -1,29 +1,31 @@
 package com.thenewmotion.ocpi
 package registration
 
-import scala.concurrent.Future
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
-import com.thenewmotion.ocpi.msgs.{AuthToken, GlobalPartyId, Url}
+import com.thenewmotion.ocpi.common.IOMatchersExt
 import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
 import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes.BusinessDetails
 import com.thenewmotion.ocpi.msgs.v2_1.Credentials.Creds
+import com.thenewmotion.ocpi.msgs.{AuthToken, GlobalPartyId, Url, Versions}
 import com.thenewmotion.ocpi.registration.RegistrationError.{SendingCredentialsFailed, UpdatingCredentialsFailed, VersionDetailsRetrievalFailed, VersionsRetrievalFailed}
-import org.specs2.matcher.{EitherMatchers, FutureMatchers}
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.EitherMatchers
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import org.specs2.specification.core.Env
+import scala.concurrent.{ExecutionContext, Future}
 
 class RegistrationClientSpec(environment: Env)
   extends Specification
   with Mockito
-  with FutureMatchers
+  with IOMatchersExt
   with EitherMatchers {
 
-  implicit val ee = environment.executionEnv
-  implicit val ec = environment.executionContext
+  implicit val ee: ExecutionEnv = environment.executionEnv
+  implicit val ec: ExecutionContext = environment.executionContext
   implicit val mat: ActorMaterializer = null
 
   val uri = Uri("http://localhost/nothingHere")
@@ -37,16 +39,24 @@ class RegistrationClientSpec(environment: Env)
 
   "Registration client recovers errors when" >> {
     "getting their versions" >> new TestScope {
-      client.getTheirVersions(uri, ourToken) must beLeft(VersionsRetrievalFailed: RegistrationError).await
+      client.getTheirVersions(uri, ourToken) must returnValueLike[Either[RegistrationError, List[Versions.Version]]]{
+        case Left(VersionsRetrievalFailed ) => ok
+      }
     }
     "getting their version details" >> new TestScope {
-      client.getTheirVersionDetails(uri, ourToken) must beLeft(VersionDetailsRetrievalFailed: RegistrationError).await
+      client.getTheirVersionDetails(uri, ourToken) must returnValueLike[Either[RegistrationError, Versions.VersionDetails]]{
+        case Left(VersionDetailsRetrievalFailed ) => ok
+      }
     }
     "sending credentials" >> new TestScope {
-      client.sendCredentials(Url("url"), ourToken, creds) must beLeft(SendingCredentialsFailed: RegistrationError).await
+      client.sendCredentials(Url("url"), ourToken, creds) must returnValueLike[Either[RegistrationError, Creds[Theirs]]]{
+        case Left(SendingCredentialsFailed ) => ok
+      }
     }
     "updating credentials" >> new TestScope {
-      client.updateCredentials(Url("url"), ourToken, creds) must beLeft(UpdatingCredentialsFailed: RegistrationError).await
+      client.updateCredentials(Url("url"), ourToken, creds) must returnValueLike[Either[RegistrationError, Creds[Theirs]]]{
+        case Left(UpdatingCredentialsFailed ) => ok
+      }
     }
   }
 

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationClientSpec.scala
@@ -1,9 +1,9 @@
 package com.thenewmotion.ocpi
 package registration
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model.Uri
-import akka.stream.ActorMaterializer
 import cats.effect.IO
 import com.thenewmotion.ocpi.common.IOMatchersExt
 import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
@@ -27,7 +27,7 @@ class RegistrationClientSpec(environment: Env)
 
   implicit val ee: ExecutionEnv = environment.executionEnv
   implicit val ec: ExecutionContext = environment.executionContext
-  implicit val mat: ActorMaterializer = null
+  implicit val sys: ActorSystem = ActorSystem()
 
   val uri = Uri("http://localhost/nothingHere")
   val ourToken = AuthToken[Ours]("token")

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationRouteSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationRouteSpec.scala
@@ -171,7 +171,7 @@ class RegistrationRouteSpec(implicit ee: ExecutionEnv) extends Specification wit
     val newCredsToConnectToUs = credsToConnectToUs.copy[Ours](token = AuthToken[Theirs]("abc"))
 
     // mock
-    val registrationService = mock[RegistrationService]
+    val registrationService = mock[RegistrationService[IO]]
 
     //default mocks
     registrationService.reactToNewCredsRequest(any(), any(), any())(any(), any()) returns

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationServiceSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationServiceSpec.scala
@@ -297,7 +297,7 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
       theirGlobalId
     )
 
-    var _client = mock[RegistrationClient]
+    var _client = mock[RegistrationClient[IO]]
 
     // React to credentials request
     _client.getTheirVersions(credsToConnectToThem.url, tokenToConnectToThem) returns IO.pure(

--- a/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationServiceSpec.scala
+++ b/endpoints-registration/src/test/scala/com/thenewmotion/ocpi/registration/RegistrationServiceSpec.scala
@@ -4,7 +4,7 @@ package registration
 import java.time.ZonedDateTime
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.testkit.TestKit
 import cats.effect.{ContextShift, IO}
 import com.thenewmotion.ocpi.common.IOMatchersExt
@@ -264,8 +264,6 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
   class RegistrationTestScope(_system: ActorSystem) extends TestKit(_system) with Scope {
 
     def this() = this(ActorSystem("ocpi-allstarts"))
-
-    implicit val materializer = ActorMaterializer()
 
     implicit val http = Http()
 

--- a/endpoints-versions/src/test/scala/com/thenewmotion/ocpi/VersionsRouteSpec.scala
+++ b/endpoints-versions/src/test/scala/com/thenewmotion/ocpi/VersionsRouteSpec.scala
@@ -34,7 +34,7 @@ class VersionsRouteSpec extends Specification with Specs2RouteTest with Mockito 
         handled must beTrue
 
         val json = responseAs[String].parseJson
-        json.extract[Int]('status_code) mustEqual 2011
+        json.extract[Int](Symbol("status_code")) mustEqual 2011
       }
     }
 
@@ -46,7 +46,7 @@ class VersionsRouteSpec extends Specification with Specs2RouteTest with Mockito 
         handled must beTrue
 
         val json = responseAs[String].parseJson
-        json.extract[Int]('status_code) mustEqual 2010
+        json.extract[Int](Symbol("status_code")) mustEqual 2010
       }
     }
 
@@ -58,9 +58,9 @@ class VersionsRouteSpec extends Specification with Specs2RouteTest with Mockito 
         handled must beTrue
 
         val json = responseAs[String].parseJson
-        json.extract[Int]('status_code) mustEqual 1000
-        json.extract[String]('data / * / 'version) mustEqual List("2.1")
-        json.extract[String]('data / * / 'url) mustEqual List("http://example.com/cpo/versions/2.1")
+        json.extract[Int](Symbol("status_code")) mustEqual 1000
+        json.extract[String](Symbol("data") / * / Symbol("version")) mustEqual List("2.1")
+        json.extract[String](Symbol("data") / * / Symbol("url")) mustEqual List("http://example.com/cpo/versions/2.1")
       }
     }
 
@@ -70,10 +70,10 @@ class VersionsRouteSpec extends Specification with Specs2RouteTest with Mockito 
         handled must beTrue
 
         val json = responseAs[String].parseJson
-        json.extract[Int]('status_code) mustEqual 1000
-        json.extract[String]('data / 'version) mustEqual "2.1"
-        json.extract[String]('data / 'endpoints / * / 'identifier) mustEqual List("credentials", "locations", "tokens")
-        json.extract[String]('data / 'endpoints / * / 'url) mustEqual
+        json.extract[Int](Symbol("status_code")) mustEqual 1000
+        json.extract[String](Symbol("data") / Symbol("version")) mustEqual "2.1"
+        json.extract[String](Symbol("data") / Symbol("endpoints") / * / Symbol("identifier")) mustEqual List("credentials", "locations", "tokens")
+        json.extract[String](Symbol("data") / Symbol("endpoints") / * / Symbol("url")) mustEqual
           List(
             "http://example.com/cpo/versions/2.1/credentials",
             "http://example.com/cpo/versions/2.1/locations",
@@ -88,10 +88,10 @@ class VersionsRouteSpec extends Specification with Specs2RouteTest with Mockito 
         handled must beTrue
 
         val json = responseAs[String].parseJson
-        json.extract[Int]('status_code) mustEqual 1000
-        json.extract[String]('data / 'version) mustEqual "2.1"
-        json.extract[String]('data / 'endpoints / * / 'identifier) mustEqual List("credentials", "locations", "tokens")
-        json.extract[String]('data / 'endpoints / * / 'url) mustEqual
+        json.extract[Int](Symbol("status_code")) mustEqual 1000
+        json.extract[String](Symbol("data") / Symbol("version")) mustEqual "2.1"
+        json.extract[String](Symbol("data") / Symbol("endpoints") / * / Symbol("identifier")) mustEqual List("credentials", "locations", "tokens")
+        json.extract[String](Symbol("data") / Symbol("endpoints") / * / Symbol("url")) mustEqual
           List(
             "http://example.com/cpo/versions/2.1/credentials",
             "http://example.com/cpo/versions/2.1/locations",

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
@@ -3,41 +3,42 @@ package example
 
 import _root_.akka.actor.ActorSystem
 import _root_.akka.http.scaladsl.Http
+import _root_.akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import _root_.akka.http.scaladsl.server.Directives._
 import _root_.akka.stream.ActorMaterializer
+import cats.effect.{ContextShift, IO}
 import com.thenewmotion.ocpi.VersionsRoute.OcpiVersionConfig
 import com.thenewmotion.ocpi.common.TokenAuthenticator
 import com.thenewmotion.ocpi.msgs.Ownership.Theirs
 import com.thenewmotion.ocpi.msgs.Versions.EndpointIdentifier._
 import com.thenewmotion.ocpi.msgs.Versions.{Endpoint, VersionNumber}
 import com.thenewmotion.ocpi.msgs._
+import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
 import com.thenewmotion.ocpi.msgs.v2_1.Credentials.Creds
 import com.thenewmotion.ocpi.registration.{RegistrationClient, RegistrationRepo, RegistrationRoute, RegistrationService}
-import _root_.akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import com.thenewmotion.ocpi.msgs.sprayjson.v2_1.protocol._
-import scala.concurrent.Future
 
-class ExampleRegistrationRepo extends RegistrationRepo {
-  def isPartyRegistered(globalPartyId: GlobalPartyId) = ???
-  def findTheirAuthToken(globalPartyId: GlobalPartyId) = ???
+
+class ExampleRegistrationRepo extends RegistrationRepo[IO] {
+  def isPartyRegistered(globalPartyId: GlobalPartyId): IO[Boolean] = ???
+  def findTheirAuthToken(globalPartyId: GlobalPartyId): IO[Option[AuthToken[Theirs]]] = ???
   def persistInfoAfterConnectToUs(
     globalPartyId: GlobalPartyId,
     version: VersionNumber,
     newTokenToConnectToUs: AuthToken[Theirs],
     credsToConnectToThem: Creds[Theirs],
     endpoints: Iterable[Endpoint]
-  ) = ???
+  ): IO[Unit] = ???
 
   def persistInfoAfterConnectToThem(
     version: VersionNumber,
     newTokenToConnectToUs: AuthToken[Theirs],
     newCredToConnectToThem: Creds[Theirs],
     endpoints: Iterable[Endpoint]
-  ) = ???
+  ): IO[Unit] = ???
 
   def deletePartyInformation(
     globalPartyId: GlobalPartyId
-  ): Future[Unit] = ???
+  ): IO[Unit] = ???
 }
 
 
@@ -46,6 +47,7 @@ object ExampleApp extends App {
   implicit val executor = system.dispatcher
   implicit val materializer = ActorMaterializer()
   implicit val http = Http()
+  implicit private val ctxShift: ContextShift[IO] = IO.contextShift(executor)
 
   val repo = new ExampleRegistrationRepo()
 
@@ -59,10 +61,11 @@ object ExampleApp extends App {
     ourVersions = Set(VersionNumber.`2.1`),
     ourVersionsUrl = Url("www.ocpi-example.com/ocpi/versions"))
 
-  val registrationRoute = RegistrationRoute(service)
+  import com.thenewmotion.ocpi.common.HktMarshallableInstances._
+  val registrationRoute = RegistrationRoute[IO](service)
 
   val versionRoute = VersionsRoute(
-    Future(Map(VersionNumber.`2.1` -> OcpiVersionConfig(
+    IO.pure(Map(VersionNumber.`2.1` -> OcpiVersionConfig(
       Map(
         Credentials -> Right(registrationRoute.apply),
         Locations -> Left(Url("http://locations.ocpi-example.com"))
@@ -70,7 +73,7 @@ object ExampleApp extends App {
     )))
   )
 
-  val auth = new TokenAuthenticator(_ => Future.successful(Some(GlobalPartyId("NL", "TNM"))))
+  val auth = new TokenAuthenticator(_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
 
   val topLevelRoute = {
     pathPrefix("example") {

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
@@ -73,7 +73,7 @@ object ExampleApp extends App {
     )))
   )
 
-  val auth = new TokenAuthenticator(_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
+  val auth = new TokenAuthenticator[IO](_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
 
   val topLevelRoute = {
     pathPrefix("example") {

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
@@ -5,7 +5,6 @@ import _root_.akka.actor.ActorSystem
 import _root_.akka.http.scaladsl.Http
 import _root_.akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import _root_.akka.http.scaladsl.server.Directives._
-import _root_.akka.stream.ActorMaterializer
 import cats.effect.{ContextShift, IO}
 import com.thenewmotion.ocpi.VersionsRoute.OcpiVersionConfig
 import com.thenewmotion.ocpi.common.TokenAuthenticator
@@ -45,7 +44,6 @@ class ExampleRegistrationRepo extends RegistrationRepo[IO] {
 object ExampleApp extends App {
   implicit val system = ActorSystem()
   implicit val executor = system.dispatcher
-  implicit val materializer = ActorMaterializer()
   implicit val http = Http()
   implicit private val ctxShift: ContextShift[IO] = IO.contextShift(executor)
 
@@ -85,6 +83,6 @@ object ExampleApp extends App {
     }
   }
 
-  Http().bindAndHandle(topLevelRoute, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bindFlow(topLevelRoute)
 
 }

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleApp.scala
@@ -51,7 +51,7 @@ object ExampleApp extends App {
 
   val repo = new ExampleRegistrationRepo()
 
-  val client = new RegistrationClient()
+  val client = new RegistrationClient[IO]()
 
   val service = new RegistrationService(
     client,

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
@@ -44,7 +44,7 @@ object ExampleCatsIO extends IOApp {
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   val tokensRoute = MspTokensRoute(service)
 
-  val auth = new TokenAuthenticator(_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
+  val auth = new TokenAuthenticator[IO](_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
 
   val topLevelRoute = {
     pathPrefix("example") {

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
@@ -4,7 +4,6 @@ import java.time.ZonedDateTime
 import _root_.akka.actor.ActorSystem
 import _root_.akka.http.scaladsl.Http
 import _root_.akka.http.scaladsl.server.Directives._
-import _root_.akka.stream.ActorMaterializer
 import cats.effect.{ExitCode, IO, IOApp}
 import com.thenewmotion.ocpi.common.{Pager, PaginatedResult, TokenAuthenticator}
 import com.thenewmotion.ocpi.msgs._
@@ -33,7 +32,6 @@ object ExampleCatsIO extends IOApp {
 
   implicit val system = ActorSystem()
   implicit val executor = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   val service = IOBasedTokensService
 
@@ -58,6 +56,6 @@ object ExampleCatsIO extends IOApp {
 
 
   override def run(args: List[String]): IO[ExitCode] =
-    IO.fromFuture(IO(Http().bindAndHandle(topLevelRoute, "localhost", 8080))).map(_ => ExitCode.Success)
+    IO.fromFuture(IO(Http().newServerAt("localhost", 8080).bindFlow(topLevelRoute))).map(_ => ExitCode.Success)
 
 }

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
@@ -1,0 +1,64 @@
+package com.thenewmotion.ocpi.example
+
+import java.time.ZonedDateTime
+import _root_.akka.actor.ActorSystem
+import _root_.akka.http.scaladsl.Http
+import _root_.akka.http.scaladsl.server.Directives._
+import _root_.akka.stream.ActorMaterializer
+import cats.effect.{ExitCode, IO, IOApp}
+import com.thenewmotion.ocpi.common.{Pager, PaginatedResult, TokenAuthenticator}
+import com.thenewmotion.ocpi.msgs._
+import com.thenewmotion.ocpi.msgs.v2_1.Tokens._
+import com.thenewmotion.ocpi.tokens.{AuthorizeError, MspTokensRoute, MspTokensService}
+
+/**
+  * Uses cats-effect's IO datatype
+  */
+object ExampleCatsIO extends IOApp {
+
+  object IOBasedTokensService extends MspTokensService[IO] {
+    def tokens(
+      globalPartyId: GlobalPartyId,
+      pager: Pager,
+      dateFrom: Option[ZonedDateTime] = None,
+      dateTo: Option[ZonedDateTime] = None
+    ): IO[PaginatedResult[Token]] = IO.pure(PaginatedResult(Nil, 0))
+
+    def authorize(
+      globalPartyId: GlobalPartyId,
+      tokenUid: TokenUid,
+      locationReferences: Option[LocationReferences]
+    ): IO[Either[AuthorizeError, AuthorizationInfo]] = IO.pure(Right(AuthorizationInfo(Allowed.Allowed)))
+  }
+
+  implicit val system = ActorSystem()
+  implicit val executor = system.dispatcher
+  implicit val materializer = ActorMaterializer()
+  implicit val http = Http()
+
+  val service = IOBasedTokensService
+
+  import com.thenewmotion.ocpi.common.HktMarshallableInstances._
+  import com.thenewmotion.ocpi.msgs.circe.v2_1.CommonJsonProtocol._
+  import com.thenewmotion.ocpi.msgs.circe.v2_1.TokensJsonProtocol._
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  val tokensRoute = MspTokensRoute(service)
+
+  val auth = new TokenAuthenticator(_ => IO.pure(Some(GlobalPartyId("NL", "TNM"))))
+
+  val topLevelRoute = {
+    pathPrefix("example") {
+      authenticateOrRejectWithChallenge(auth) { user =>
+        pathPrefix("versions") {
+          tokensRoute(user)
+        }
+      }
+    }
+  }
+
+
+
+  override def run(args: List[String]): IO[ExitCode] =
+    IO.fromFuture(IO(Http().bindAndHandle(topLevelRoute, "localhost", 8080))).map(_ => ExitCode.Success)
+
+}

--- a/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
+++ b/example/src/main/scala/com/thenewmotion/ocpi/example/ExampleCatsIO.scala
@@ -34,7 +34,6 @@ object ExampleCatsIO extends IOApp {
   implicit val system = ActorSystem()
   implicit val executor = system.dispatcher
   implicit val materializer = ActorMaterializer()
-  implicit val http = Http()
 
   val service = IOBasedTokensService
 

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CdrsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CdrsJsonProtocol.scala
@@ -12,14 +12,14 @@ trait CdrsJsonProtocol {
   implicit val cdrIdE: Encoder[CdrId] = stringEncoder(_.value)
   implicit val cdrIdD: Decoder[CdrId] = tryStringDecoder(CdrId.apply)
 
-  implicit val cdrDimensionE: Encoder[CdrDimension] = deriveEncoder
-  implicit val cdrDimensionD: Decoder[CdrDimension] = deriveDecoder
+  implicit val cdrDimensionE: Encoder[CdrDimension] = deriveConfiguredEncoder
+  implicit val cdrDimensionD: Decoder[CdrDimension] = deriveConfiguredDecoder
 
-  implicit val chargingPeriodE: Encoder[ChargingPeriod] = deriveEncoder
-  implicit val chargingPeriodD: Decoder[ChargingPeriod] = deriveDecoder
+  implicit val chargingPeriodE: Encoder[ChargingPeriod] = deriveConfiguredEncoder
+  implicit val chargingPeriodD: Decoder[ChargingPeriod] = deriveConfiguredDecoder
 
-  implicit val cdrE: Encoder[Cdr] = deriveEncoder
-  implicit val cdrD: Decoder[Cdr] = deriveDecoder
+  implicit val cdrE: Encoder[Cdr] = deriveConfiguredEncoder
+  implicit val cdrD: Decoder[Cdr] = deriveConfiguredDecoder
 }
 
 object CdrsJsonProtocol extends CdrsJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommandsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommandsJsonProtocol.scala
@@ -11,20 +11,20 @@ import LocationsJsonProtocol._
 import SessionJsonProtocol._
 
 trait CommandsJsonProtocol {
-  implicit val commandResponseE: Encoder[CommandResponse] = deriveEncoder
-  implicit val commandResponseD: Decoder[CommandResponse] = deriveDecoder
+  implicit val commandResponseE: Encoder[CommandResponse] = deriveConfiguredEncoder
+  implicit val commandResponseD: Decoder[CommandResponse] = deriveConfiguredDecoder
 
-  implicit val reserveNowE: Encoder[Command.ReserveNow] = deriveEncoder
-  implicit val reserveNowD: Decoder[Command.ReserveNow] = deriveDecoder
+  implicit val reserveNowE: Encoder[Command.ReserveNow] = deriveConfiguredEncoder
+  implicit val reserveNowD: Decoder[Command.ReserveNow] = deriveConfiguredDecoder
 
-  implicit val startSessionE: Encoder[Command.StartSession] = deriveEncoder
-  implicit val startSessionD: Decoder[Command.StartSession] = deriveDecoder
+  implicit val startSessionE: Encoder[Command.StartSession] = deriveConfiguredEncoder
+  implicit val startSessionD: Decoder[Command.StartSession] = deriveConfiguredDecoder
 
-  implicit val stopSessionE: Encoder[Command.StopSession] = deriveEncoder
-  implicit val stopSessionD: Decoder[Command.StopSession] = deriveDecoder
+  implicit val stopSessionE: Encoder[Command.StopSession] = deriveConfiguredEncoder
+  implicit val stopSessionD: Decoder[Command.StopSession] = deriveConfiguredDecoder
 
-  implicit val unlockConnectorE: Encoder[UnlockConnector] = deriveEncoder
-  implicit val unlockConnectorD: Decoder[UnlockConnector] = deriveDecoder
+  implicit val unlockConnectorE: Encoder[UnlockConnector] = deriveConfiguredEncoder
+  implicit val unlockConnectorD: Decoder[UnlockConnector] = deriveConfiguredDecoder
 }
 
 object CommandsJsonProtocol extends CommandsJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CommonJsonProtocol.scala
@@ -88,21 +88,20 @@ trait CommonJsonProtocol {
       case e if e.history == List(DownField("data")) => successPagedRespWithoutDataD[T]
     }
 
-  implicit val errorRespE: Encoder[ErrorResp] = deriveEncoder
-  implicit val errorRespD: Decoder[ErrorResp] = deriveDecoder
+  implicit val errorRespE: Encoder[ErrorResp] = deriveConfiguredEncoder
+  implicit val errorRespD: Decoder[ErrorResp] = deriveConfiguredDecoder
 
-  implicit def successRespE[D : Encoder]: Encoder[SuccessResp[D]] = deriveEncoder
-  implicit def successRespD[D : Decoder]: Decoder[SuccessResp[D]] = deriveDecoder
+  implicit def successRespE[D : Encoder]: Encoder[SuccessResp[D]] = deriveConfiguredEncoder
+  implicit def successRespD[D : Decoder]: Decoder[SuccessResp[D]] = deriveConfiguredDecoder
 
+  implicit val displayTextE: Encoder[DisplayText] = deriveConfiguredEncoder
+  implicit val displayTextD: Decoder[DisplayText] = deriveConfiguredDecoder
 
-  implicit val displayTextE: Encoder[DisplayText] = deriveEncoder
-  implicit val displayTextD: Decoder[DisplayText] = deriveDecoder
+  implicit val imageE: Encoder[Image] = deriveConfiguredEncoder
+  implicit val imageD: Decoder[Image] = deriveConfiguredDecoder
 
-  implicit val imageE: Encoder[Image] = deriveEncoder
-  implicit val imageD: Decoder[Image] = deriveDecoder
-
-  implicit val businessDetailsE: Encoder[BusinessDetails] = deriveEncoder
-  implicit val businessDetailsD: Decoder[BusinessDetails] = deriveDecoder
+  implicit val businessDetailsE: Encoder[BusinessDetails] = deriveConfiguredEncoder
+  implicit val businessDetailsD: Decoder[BusinessDetails] = deriveConfiguredDecoder
 }
 
 object CommonJsonProtocol extends CommonJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/LocationsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/LocationsJsonProtocol.scala
@@ -19,14 +19,14 @@ trait LocationsJsonProtocol {
   implicit val evseUidE: Encoder[EvseUid] = stringEncoder(_.value)
   implicit val evseUidD: Decoder[EvseUid] = tryStringDecoder(EvseUid.apply)
 
-  implicit val energySourceE: Encoder[EnergySource] = deriveEncoder
-  implicit val energySourceD: Decoder[EnergySource] = deriveDecoder
+  implicit val energySourceE: Encoder[EnergySource] = deriveConfiguredEncoder
+  implicit val energySourceD: Decoder[EnergySource] = deriveConfiguredDecoder
 
-  implicit val environmentalImpactE: Encoder[EnvironmentalImpact] = deriveEncoder
-  implicit val environmentalImpactD: Decoder[EnvironmentalImpact] = deriveDecoder
+  implicit val environmentalImpactE: Encoder[EnvironmentalImpact] = deriveConfiguredEncoder
+  implicit val environmentalImpactD: Decoder[EnvironmentalImpact] = deriveConfiguredDecoder
 
-  implicit val energyMixE: Encoder[EnergyMix] = deriveEncoder
-  implicit val energyMixD: Decoder[EnergyMix] = deriveDecoder
+  implicit val energyMixE: Encoder[EnergyMix] = deriveConfiguredEncoder
+  implicit val energyMixD: Decoder[EnergyMix] = deriveConfiguredDecoder
 
   implicit val latitudeE: Encoder[Latitude] = stringEncoder(_.toString)
   implicit val latitudeD: Decoder[Latitude] =
@@ -36,41 +36,41 @@ trait LocationsJsonProtocol {
   implicit val longitudeD: Decoder[Longitude] =
     if (strict) tryStringDecoder(Longitude.strict) else tryStringDecoder(Longitude.apply)
 
-  implicit val geoLocationE: Encoder[GeoLocation] = deriveEncoder
-  implicit val geoLocationD: Decoder[GeoLocation] = deriveDecoder
+  implicit val geoLocationE: Encoder[GeoLocation] = deriveConfiguredEncoder
+  implicit val geoLocationD: Decoder[GeoLocation] = deriveConfiguredDecoder
 
-  implicit val additionalGeoLocationE: Encoder[AdditionalGeoLocation] = deriveEncoder
-  implicit val additionalGeoLocationD: Decoder[AdditionalGeoLocation] = deriveDecoder
+  implicit val additionalGeoLocationE: Encoder[AdditionalGeoLocation] = deriveConfiguredEncoder
+  implicit val additionalGeoLocationD: Decoder[AdditionalGeoLocation] = deriveConfiguredDecoder
 
-  implicit val regularHoursE: Encoder[RegularHours] = deriveEncoder
-  implicit val regularHoursD: Decoder[RegularHours] = deriveDecoder
+  implicit val regularHoursE: Encoder[RegularHours] = deriveConfiguredEncoder
+  implicit val regularHoursD: Decoder[RegularHours] = deriveConfiguredDecoder
 
-  implicit val exceptionalPeriodE: Encoder[ExceptionalPeriod] = deriveEncoder
-  implicit val exceptionalPeriodD: Decoder[ExceptionalPeriod] = deriveDecoder
+  implicit val exceptionalPeriodE: Encoder[ExceptionalPeriod] = deriveConfiguredEncoder
+  implicit val exceptionalPeriodD: Decoder[ExceptionalPeriod] = deriveConfiguredDecoder
 
-  implicit val hoursE: Encoder[Hours] = deriveEncoder
-  implicit val hoursD: Decoder[Hours] = deriveDecoder
+  implicit val hoursE: Encoder[Hours] = deriveConfiguredEncoder
+  implicit val hoursD: Decoder[Hours] = deriveConfiguredDecoder
 
-  implicit val connectorE: Encoder[Connector] = deriveEncoder
-  implicit val connectorD: Decoder[Connector] = deriveDecoder
+  implicit val connectorE: Encoder[Connector] = deriveConfiguredEncoder
+  implicit val connectorD: Decoder[Connector] = deriveConfiguredDecoder
 
-  implicit val connectorPatchE: Encoder[ConnectorPatch] = deriveEncoder
-  implicit val connectorPatchD: Decoder[ConnectorPatch] = deriveDecoder
+  implicit val connectorPatchE: Encoder[ConnectorPatch] = deriveConfiguredEncoder
+  implicit val connectorPatchD: Decoder[ConnectorPatch] = deriveConfiguredDecoder
 
-  implicit val statusScheduleE: Encoder[StatusSchedule] = deriveEncoder
-  implicit val statusScheduleD: Decoder[StatusSchedule] = deriveDecoder
+  implicit val statusScheduleE: Encoder[StatusSchedule] = deriveConfiguredEncoder
+  implicit val statusScheduleD: Decoder[StatusSchedule] = deriveConfiguredDecoder
 
-  implicit val evseE: Encoder[Evse] = deriveEncoder
-  implicit val evseD: Decoder[Evse] = deriveDecoder
+  implicit val evseE: Encoder[Evse] = deriveConfiguredEncoder
+  implicit val evseD: Decoder[Evse] = deriveConfiguredDecoder
 
-  implicit val evsePatchE: Encoder[EvsePatch] = deriveEncoder
-  implicit val evsePatchD: Decoder[EvsePatch] = deriveDecoder
+  implicit val evsePatchE: Encoder[EvsePatch] = deriveConfiguredEncoder
+  implicit val evsePatchD: Decoder[EvsePatch] = deriveConfiguredDecoder
 
-  implicit val locationE: Encoder[Location] = deriveEncoder
-  implicit val locationD: Decoder[Location] = deriveDecoder
+  implicit val locationE: Encoder[Location] = deriveConfiguredEncoder
+  implicit val locationD: Decoder[Location] = deriveConfiguredDecoder
 
-  implicit val locationPatchE: Encoder[LocationPatch] = deriveEncoder
-  implicit val locationPatchD: Decoder[LocationPatch] = deriveDecoder
+  implicit val locationPatchE: Encoder[LocationPatch] = deriveConfiguredEncoder
+  implicit val locationPatchD: Decoder[LocationPatch] = deriveConfiguredDecoder
 }
 
 object LocationsJsonProtocol extends LocationsJsonProtocol {

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/SessionJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/SessionJsonProtocol.scala
@@ -13,11 +13,11 @@ trait SessionJsonProtocol {
   implicit val sessionIdE: Encoder[SessionId] = stringEncoder(_.value)
   implicit val sessionIdD: Decoder[SessionId] = tryStringDecoder(SessionId.apply)
 
-  implicit val sessionE: Encoder[Session] = deriveEncoder
-  implicit val sessionD: Decoder[Session] = deriveDecoder
+  implicit val sessionE: Encoder[Session] = deriveConfiguredEncoder
+  implicit val sessionD: Decoder[Session] = deriveConfiguredDecoder
 
-  implicit val sessionPatchE: Encoder[SessionPatch] = deriveEncoder
-  implicit val sessionPatchD: Decoder[SessionPatch] = deriveDecoder
+  implicit val sessionPatchE: Encoder[SessionPatch] = deriveConfiguredEncoder
+  implicit val sessionPatchD: Decoder[SessionPatch] = deriveConfiguredDecoder
 }
 
 object SessionJsonProtocol extends SessionJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TariffsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TariffsJsonProtocol.scala
@@ -12,17 +12,17 @@ trait TariffsJsonProtocol {
   implicit val tariffIdE: Encoder[TariffId] = stringEncoder(_.value)
   implicit val tariffIdD: Decoder[TariffId] = tryStringDecoder(TariffId.apply)
 
-  implicit val priceComponentE: Encoder[PriceComponent] = deriveEncoder
-  implicit val priceComponentD: Decoder[PriceComponent] = deriveDecoder
+  implicit val priceComponentE: Encoder[PriceComponent] = deriveConfiguredEncoder
+  implicit val priceComponentD: Decoder[PriceComponent] = deriveConfiguredDecoder
 
-  implicit val tariffRestrictionsE: Encoder[TariffRestrictions] = deriveEncoder
-  implicit val tariffRestrictionsD: Decoder[TariffRestrictions] = deriveDecoder
+  implicit val tariffRestrictionsE: Encoder[TariffRestrictions] = deriveConfiguredEncoder
+  implicit val tariffRestrictionsD: Decoder[TariffRestrictions] = deriveConfiguredDecoder
 
-  implicit val tariffElementE: Encoder[TariffElement] = deriveEncoder
-  implicit val tariffElementD: Decoder[TariffElement] = deriveDecoder
+  implicit val tariffElementE: Encoder[TariffElement] = deriveConfiguredEncoder
+  implicit val tariffElementD: Decoder[TariffElement] = deriveConfiguredDecoder
 
-  implicit val tariffE: Encoder[Tariff] = deriveEncoder
-  implicit val tariffD: Decoder[Tariff] = deriveDecoder
+  implicit val tariffE: Encoder[Tariff] = deriveConfiguredEncoder
+  implicit val tariffD: Decoder[Tariff] = deriveConfiguredDecoder
 }
 
 object TariffsJsonProtocol extends TariffsJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TokensJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/TokensJsonProtocol.scala
@@ -13,17 +13,17 @@ trait TokensJsonProtocol {
   implicit val authIdE: Encoder[AuthId] = stringEncoder(_.value)
   implicit val authIdD: Decoder[AuthId] = tryStringDecoder(AuthId.apply)
 
-  implicit val tokenE: Encoder[Token] = deriveEncoder
-  implicit val tokenD: Decoder[Token] = deriveDecoder
+  implicit val tokenE: Encoder[Token] = deriveConfiguredEncoder
+  implicit val tokenD: Decoder[Token] = deriveConfiguredDecoder
 
-  implicit val tokenPatchE: Encoder[TokenPatch] = deriveEncoder
-  implicit val tokenPatchD: Decoder[TokenPatch] = deriveDecoder
+  implicit val tokenPatchE: Encoder[TokenPatch] = deriveConfiguredEncoder
+  implicit val tokenPatchD: Decoder[TokenPatch] = deriveConfiguredDecoder
 
-  implicit val locationReferencesE: Encoder[LocationReferences] = deriveEncoder
-  implicit val locationReferencesD: Decoder[LocationReferences] = deriveDecoder
+  implicit val locationReferencesE: Encoder[LocationReferences] = deriveConfiguredEncoder
+  implicit val locationReferencesD: Decoder[LocationReferences] = deriveConfiguredDecoder
 
-  implicit val authorizationInfoE: Encoder[AuthorizationInfo] = deriveEncoder
-  implicit val authorizationInfoD: Decoder[AuthorizationInfo] = deriveDecoder
+  implicit val authorizationInfoE: Encoder[AuthorizationInfo] = deriveConfiguredEncoder
+  implicit val authorizationInfoD: Decoder[AuthorizationInfo] = deriveConfiguredDecoder
 }
 
 object TokensJsonProtocol extends TokensJsonProtocol

--- a/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/VersionsJsonProtocol.scala
+++ b/msgs-circe/src/main/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/VersionsJsonProtocol.scala
@@ -11,14 +11,14 @@ trait VersionsJsonProtocol {
   implicit val versionNumberE: Encoder[VersionNumber] = stringEncoder(_.toString)
   implicit val versionNumberD: Decoder[VersionNumber] = tryStringDecoder(VersionNumber.apply)
 
-  implicit val versionE: Encoder[Version] = deriveEncoder
-  implicit val versionD: Decoder[Version] = deriveDecoder
+  implicit val versionE: Encoder[Version] = deriveConfiguredEncoder
+  implicit val versionD: Decoder[Version] = deriveConfiguredDecoder
 
-  implicit val endpointE: Encoder[Endpoint] = deriveEncoder
-  implicit val endpointD: Decoder[Endpoint] = deriveDecoder
+  implicit val endpointE: Encoder[Endpoint] = deriveConfiguredEncoder
+  implicit val endpointD: Decoder[Endpoint] = deriveConfiguredDecoder
 
-  implicit val versionDetailsE: Encoder[VersionDetails] = deriveEncoder
-  implicit val versionDetailsD: Decoder[VersionDetails] = deriveDecoder
+  implicit val versionDetailsE: Encoder[VersionDetails] = deriveConfiguredEncoder
+  implicit val versionDetailsD: Decoder[VersionDetails] = deriveConfiguredDecoder
 }
 
 object VersionsJsonProtocol extends VersionsJsonProtocol

--- a/msgs-circe/src/test/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CirceJsonSpec.scala
+++ b/msgs-circe/src/test/scala/com/thenewmotion/ocpi/msgs/circe/v2_1/CirceJsonSpec.scala
@@ -22,6 +22,6 @@ trait CirceJsonSpec extends GenericJsonSpec[Json, Decoder, Encoder] {
   override def objToJson[T : Encoder](t: T): Json = {
     // we can only remove the null keys when printing, so we print then re-parse, bit hacky but works
     val printer = Printer.noSpaces.copy(dropNullValues = true)
-    parse(printer.pretty(t.asJson))
+    parse(printer.print(t.asJson))
   }
 }

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCdrsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCdrsSpec.scala
@@ -6,7 +6,6 @@ import com.thenewmotion.ocpi.msgs.v2_1.Locations._
 import com.thenewmotion.ocpi.msgs.v2_1.Tariffs._
 import com.thenewmotion.ocpi.msgs.{CountryCode, CurrencyCode}
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericCdrsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCommonTypesSpec.scala
@@ -6,7 +6,6 @@ import com.thenewmotion.ocpi.msgs.{CurrencyCode, ErrorResp, SuccessResp}
 import com.thenewmotion.ocpi.msgs.OcpiStatusCode.{GenericClientFailure, GenericSuccess}
 import com.thenewmotion.ocpi.ZonedDateTimeParser
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericCommonTypesSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCredentialsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericCredentialsSpec.scala
@@ -5,7 +5,6 @@ import com.thenewmotion.ocpi.msgs.Ownership.{Ours, Theirs}
 import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes._
 import com.thenewmotion.ocpi.msgs.v2_1.Credentials._
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericCredentialsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericJsonSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericJsonSpec.scala
@@ -3,7 +3,6 @@ package com.thenewmotion.ocpi.msgs.v2_1
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.specification.core.Fragments
 
-import scala.language.higherKinds
 
 trait GenericJsonSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends SpecificationWithJUnit {
   def parse(s: String): J

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericLocationsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericLocationsSpec.scala
@@ -6,7 +6,6 @@ import com.thenewmotion.ocpi.msgs.v2_1.CommonTypes._
 import com.thenewmotion.ocpi.msgs.v2_1.Locations._
 import com.thenewmotion.ocpi.msgs.CountryCode
 import org.specs2.specification.core.Fragment
-import scala.language.higherKinds
 
 trait GenericLocationsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericSessionsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericSessionsSpec.scala
@@ -10,7 +10,6 @@ import Sessions.{Session, SessionId, SessionPatch, SessionStatus}
 import Tokens.AuthId
 import org.specs2.specification.core.Fragments
 
-import scala.language.higherKinds
 
 trait GenericSessionsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTariffsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTariffsSpec.scala
@@ -7,7 +7,6 @@ import com.thenewmotion.ocpi.msgs.v2_1.Tariffs.TariffDimensionType.{Flat, Parkin
 import com.thenewmotion.ocpi.msgs.v2_1.Tariffs._
 import com.thenewmotion.ocpi.msgs.{CurrencyCode, Url}
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericTariffsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTokensSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericTokensSpec.scala
@@ -3,7 +3,6 @@ package com.thenewmotion.ocpi.msgs.v2_1
 import com.thenewmotion.ocpi.msgs.v2_1.Tokens.LocationReferences
 import org.specs2.specification.Scope
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericTokensSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericVersionsSpec.scala
+++ b/msgs-json-test/src/test/scala/com/thenewmotion/ocpi/msgs/v2_1/GenericVersionsSpec.scala
@@ -5,7 +5,6 @@ import com.thenewmotion.ocpi.msgs.Url
 import com.thenewmotion.ocpi.msgs.Versions.VersionNumber._
 import com.thenewmotion.ocpi.msgs.Versions._
 import org.specs2.specification.core.Fragments
-import scala.language.higherKinds
 
 trait GenericVersionsSpec[J, GenericJsonReader[_], GenericJsonWriter[_]] extends
   GenericJsonSpec[J, GenericJsonReader, GenericJsonWriter] {

--- a/msgs-shapeless/src/main/scala/com/thenewmotion/ocpi/msgs/shapeless/MergePatch.scala
+++ b/msgs-shapeless/src/main/scala/com/thenewmotion/ocpi/msgs/shapeless/MergePatch.scala
@@ -3,7 +3,6 @@ package com.thenewmotion.ocpi.msgs.shapeless
 import com.thenewmotion.ocpi.msgs.{Resource, ResourceType}
 import com.thenewmotion.ocpi.msgs.ResourceType.{Full, Patch}
 import scala.annotation.implicitNotFound
-import scala.language.higherKinds
 import shapeless._
 import shapeless.ops.hlist.{IsHCons, Mapper, Zip}
 

--- a/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
+++ b/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
@@ -6,7 +6,7 @@ import OcpiStatusCode.SuccessCode
 import sprayjson.SimpleStringEnumSerializer._
 import v2_1.CommonTypes._
 import com.thenewmotion.ocpi.{LocalDateParser, LocalTimeParser, ZonedDateTimeParser}
-import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFormat, JsonReader, RootJsonFormat, RootJsonReader, deserializationError}
+import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFormat, RootJsonFormat, RootJsonReader, deserializationError}
 
 import scala.util.Try
 

--- a/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
+++ b/msgs-spray-json/src/main/scala/com/thenewmotion/ocpi/msgs/sprayjson/v2_1/DefaultJsonProtocol.scala
@@ -119,7 +119,7 @@ trait DefaultJsonProtocol extends spray.json.DefaultJsonProtocol {
 
   implicit def successRespFormat[D : JsonFormat] = jsonFormat4(SuccessResp[D])
 
-  implicit val currencyCodeFormat = new JsonFormat[CurrencyCode] {
+  implicit val currencyCodeFormat: JsonFormat[CurrencyCode] = new JsonFormat[CurrencyCode] {
     override def write(obj: CurrencyCode) = JsString(obj.value)
 
     override def read(json: JsValue) = json match {

--- a/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/resource.scala
+++ b/msgs/src/main/scala/com/thenewmotion/ocpi/msgs/resource.scala
@@ -2,7 +2,6 @@ package com.thenewmotion.ocpi.msgs
 
 import com.thenewmotion.ocpi.msgs.v2_1.Id
 
-import scala.language.higherKinds
 
 sealed trait ResourceType {
   type F[_]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.5

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.2-SNAPSHOT"
+version in ThisBuild := "2.0.0-M1-SNAPSHOT"


### PR DESCRIPTION
Migrate effect type to cats-effect IO.
At the core, we still use akka-http for routes and clients so we need the typical akka implicits. 
Stream sources are also still using akka-stream.
But at the interface to the backend services implemented by the calling application code, IO (or ZIO) can be
used to model effect types.

In the following phases, we should migrate further to http4s, sttp (?) and fs2. 